### PR TITLE
Add example description in GitLab Flavored Markdown (GLFM)

### DIFF
--- a/items.yaml
+++ b/items.yaml
@@ -6,7 +6,35 @@ spec:
       name: "ecmwf-data-flavour"
       version: "1.0.0"
       description: |
-        ECMWF Data Flavour: includes the basic ECMWF software stack, with MARS client and an environment with ecCodes, Metview, Earthkit and Aviso.
+        ECWF Data Flavor
+        =======================================
+        Includes the basic ECMWF software stack, with MARS client and an environment with `ecCodes`, `Metview`, `Earthkit` and `Aviso`.
+        
+        Getting started
+        ---------------
+        
+        * Clone or download the code from the source repository.
+        * Install ansible and other dependencies. You may want to do it in its own virtual environment (`pip install -r requirements.txt`)
+        * Fetch the external requirements
+          ```bash
+          $ ansible-galaxy role install -r requirements.yml roles/
+          ```
+        
+        * Define your inventory in `inventory`
+        * Run the apropriate playbook 
+        
+          ```bash
+          $ ansible-playbook -i inventory ecmwf-data-flavour.yml
+          ```
+        
+        Author
+        ------------------
+        ECMWF for the European Weather Cloud
+        
+        <img src="https://climate.copernicus.eu/sites/default/files/inline-images/ECMWF.png"  width="120px" height="120px"> 
+        
+        ![ewc logo](https://europeanweather.cloud/sites/default/files/images/cloud-data-network-SW-v3.png){width=120px  height=120px}
+
       home: https://github.com/ewcloud/ewc-flavours
       sources:
         - https://github.com/ewcloud/ewc-flavours/blob/766090d57b3ad18d89f999e0601cb1fdf1e14eda/ecmwf-data-flavour.yml


### PR DESCRIPTION
Hello @pacospace 
As discussed, to hopefully clarify the topic of how the `description` attribute (string, multi-line) could be rendered in the Community Hub frontend, I am adding an example in [GitLab Flavored Markdown](https://docs.gitlab.com/user/markdown/) (GLFM); not to be confused with [GitHub Flavored Markdown](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) (GFM).

**RATIONALE**
For transparency, the rationale behind this suggestion: 
* To minimize the need for metadata maintenance,  we could at some point rely on hard copying of existing README files' content (or excerpts of them) to populate the `description`.  In such case, supporting markdown will ensure that the styling the README author intended persists also on the frontend. According to the [official documentation](https://docs.gitlab.co.jp/ee/development/gitlab_flavored_markdown/specification_guide/#various-markdown-specifications), GLFM extends GFM, which in turn extends the CommonMark specification, hence propping us up for high compatibility.

cc: @ecusrc 