### PR TITLE
Add user facing docs on governance

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[support@europeanweather.cloud](mailto:support@europeanweather.cloud).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org/), version 2.1,
+available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct/>.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/inclusion).
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq/>. Translations are available at
+<https://www.contributor-covenant.org/translations/>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,5 @@
 # How to Contribute
+> ⚠️ Only contributions from EWC users shall be reviewed/accepted.
 
 This project is [licensed](./LICENSE) and accepts contributions via [GitHub pull requests](https://github.com/ewcloud/ewc-community-hub/pulls) or [EWC Support Portal tickets](http://support.europeanweather.cloud).
 See the [official EWC docummentation](https://confluence.ecmwf.int/display/EWCLOUDKB/Contributing+with+your+own+new+Item) for an outline of collaboration workflow, conventions and other recommendations to make it easier for your contributions to get accepted.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 > ⚠️ Only contributions from EWC users shall be reviewed/accepted.
 
 This project is [licensed](./LICENSE) and accepts contributions via [GitHub pull requests](https://github.com/ewcloud/ewc-community-hub/pulls) or [EWC Support Portal tickets](http://support.europeanweather.cloud).
-See the [official EWC docummentation](https://confluence.ecmwf.int/display/EWCLOUDKB/Contributing+with+your+own+new+Item) for an outline of collaboration workflow, conventions and other recommendations to make it easier for your contributions to get accepted.
+See the [official EWC documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/Contributing+with+your+own+new+Item) for an outline of collaboration workflow, conventions and other recommendations to make it easier for your contributions to get accepted.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+# How to Contribute
+
+This project is [licensed](./LICENSE) and accepts contributions via [GitHub pull requests](https://github.com/ewcloud/ewc-community-hub/pulls) or [EWC Support Portal tickets](http://support.europeanweather.cloud).
+See the [official EWC docummentation](https://confluence.ecmwf.int/display/EWCLOUDKB/Contributing+with+your+own+new+Item) for an outline of collaboration workflow, conventions and other recommendations to make it easier for your contributions to get accepted.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # How to Contribute
-> ⚠️ Only contributions from EWC users shall be reviewed/accepted.
+>⚠️ Only EWC users can contribute items to the EWC Community Hub. Visit [https://europeanweather.cloud/get-access](https://europeanweather.cloud/get-access) to check whether you can gain access.
 
 This project is [licensed](./LICENSE) and accepts contributions via [GitHub pull requests](https://github.com/ewcloud/ewc-community-hub/pulls) or [EWC Support Portal tickets](http://support.europeanweather.cloud).
 See the [official EWC documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/Contributing+with+your+own+new+Item) for an outline of collaboration workflow, conventions and other recommendations to make it easier for your contributions to get accepted.


### PR DESCRIPTION
Hi @ecusrc,

This is PR comes as part of ongoing efforts for documenting the governance policies and related topics, up for review in the EWC Community Hub's Confluence space.

**What's new?**

- Documentation: Added initial version of code of conduct and refer users to contribution guidelines outlined in Confluence.

**IMPORTANT**: I will double check the URLs are valid after Confluence docs review. Pages might be moved around and break links in the docs over here.