### PR TITLE
No dependency on community docker image for manual validation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,10 +20,10 @@ jobs:
       - name: Install Node dependencies
         run: npm install -g ajv-cli
 
-      - name: Validate catalog metadata format
+      - name: Validate items metadata format
         run: |
           yq -o=json "items.yaml" > "items.json"
 
-      - name: Validate catalog metadata contents
+      - name: Validate items metadata contents
         run: |
-          ajv validate -s schemas/catalog/v1alpha1.json -d items.json --spec=draft2020
+          ajv validate -s schemas/items/v1alpha1.json -d items.json --spec=draft2020

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,12 @@
-FROM node:20-alpine3.19 AS build
+FROM node:20-alpine3.19
 
 ENV AJV_CLI_VERSION=5.0.0
 ENV AJV_FORMATS_VERSION=2.1.0
 
-# install ajv-cli and ajv-formats globally
 RUN apk add --no-cache make gcc g++ python3 && \
     npm install -g "ajv-cli@${AJV_CLI_VERSION}" "ajv-formats@${AJV_FORMATS_VERSION}" && \
     npm cache clean --force && \
     apk del make gcc g++ python3
-
-# create small runtime image out of the build image
-FROM node:20-alpine3.19
-COPY --from=build /usr/local/lib/node_modules /usr/local/lib/node_modules
-COPY --from=build /usr/local/bin /usr/local/bin
 
 ENTRYPOINT ["ajv"]
 CMD ["help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine3.19
+FROM docker.io/node:20-alpine3.19
 
 ENV AJV_CLI_VERSION=5.0.0
 ENV AJV_FORMATS_VERSION=2.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:20-alpine3.19 AS build
+
+ENV AJV_CLI_VERSION=5.0.0
+ENV AJV_FORMATS_VERSION=2.1.0
+
+# install ajv-cli and ajv-formats globally
+RUN apk add --no-cache make gcc g++ python3 && \
+    npm install -g "ajv-cli@${AJV_CLI_VERSION}" "ajv-formats@${AJV_FORMATS_VERSION}" && \
+    npm cache clean --force && \
+    apk del make gcc g++ python3
+
+# create small runtime image out of the build image
+FROM node:20-alpine3.19
+COPY --from=build /usr/local/lib/node_modules /usr/local/lib/node_modules
+COPY --from=build /usr/local/bin /usr/local/bin
+
+ENTRYPOINT ["ajv"]
+CMD ["help"]

--- a/README.md
+++ b/README.md
@@ -56,16 +56,18 @@ The pipelines are configured to run upon pull request opening, subject to approv
 
 ### Running Locally
 
-If you wish to validate changes to the metadata on your own, you can emulate the steps performed by the automation.
-Make sure your working environment has [Docker](https://docs.docker.com/engine/install/) installed.
-Then, to validate any changes in the metadata against the expected schema, simply run:
+If you wish to validate changes to the metadata on before opening a pull request, you can emulate the steps performed by the GitHub automation.
+Make sure your working environment has [Docker](https://docs.docker.com/engine/install/) installed to
+setup the validation tool locally (one time operation):
 
 ```bash
-docker run --rm \
-  -v .:/tmp:ro \
-  weibeld/ajv-cli:5.0.0 \
-  ajv \
-  -s tmp/schemas/catalog/v1alpha1.json \
+docker build --tag ewc/ajv-cli:5.0.0 .
+```
+Then, to validate any changes in the metadata against the expected schema, run:
+```bash
+docker run --rm --volume .:/tmp:ro \
+  ewc/ajv-cli:5.0.0 \
+  -s tmp/schemas/items/v1alpha1.json \
   -d /tmp/items.yaml \
   -c ajv-formats \
   --spec draft2020

--- a/schemas/items/v1alpha1.json
+++ b/schemas/items/v1alpha1.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://https://github.com/ewcloud/ewc-community-hub/blob/main/schemas/catalog/v1alpha1.json",
+   "$id": "https://github.com/ewcloud/ewc-community-hub/blob/main/schemas/items/v1alpha1.json",
   "type": "object",
   "properties": {
     "apiVersion": {


### PR DESCRIPTION
Hi @ecusrc,

This is a quick follow up to the remark you left on #20 :
> As a note for the future we might try to avoid referencing to use community docker image for the manual validation If we have better alternatives.

What's new?

-    **Self-defined Docker image for manual validation**: Added a local Dockerfile (Node + avj-cli), plus build/run instructions. No more dependency on community maintained docker images (e.g. [weibeld/docker-ajv-cli](https://github.com/weibeld/docker-ajv-cli) )
   - **Schema filename**: Changed from `catalog` to `items` to indicate the JSON schema applies to `item.yaml` file
   
 PS: feel free to squash merge. The git log here could use some trimming : )
