### PR TITLE
Fix ECMWF metadata from ewc-flavours bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ ecmwf-data-flavour:
         description: User owning the conda installation.
         type: str
     pathToMainFile: playbooks/ecmwf-data-flavour/ecmwf-data-flavour.yml
+    pathToRequirementsFile: requirements.yml
   home: https://github.com/ewcloud/ewc-flavours/tree/2.0.0/playbooks/ecmwf-data-flavour
   icon: https://raw.githubusercontent.com/ewcloud/ewc-community-hub/refs/heads/main/logos/EWCLogo.png
   license: https://github.com/ewcloud/ewc-flavours/blob/2.0.0/LICENSE

--- a/items.yaml
+++ b/items.yaml
@@ -679,6 +679,7 @@ spec:
             description: User owning the conda installation.
             type: str
         pathToMainFile: playbooks/ecmwf-data-flavour/ecmwf-data-flavour.yml
+        pathToRequirementsFile: requirements.yml
       description: |
         Includes the basic ECMWF software stack, with MARS client and an environment with `ecCodes`, `Metview`, `Earthkit` and `Aviso`.
         
@@ -1852,6 +1853,7 @@ spec:
       version: "2.0.0"
       ewccli:
         pathToMainFile: playbooks/jupyterhub-flavour/jupyterhub-flavour.yml
+        pathToRequirementsFile: requirements.yml
         inputs:
           - name: jupyterhub_local_cert_email
             description: "Email used for the certificate."


### PR DESCRIPTION
@pacospace , this one covers all changes you added on #35, plus fixes wrongly added license urls and pins down files to their release tag, as per best-practice.

Also added the `pathToRequierementsFile`, needed for `ewccli` compatibility.