### PR TITLE
Bump version of Terraform Security Groups Item to 1.0.1

### DIFF
--- a/items.yaml
+++ b/items.yaml
@@ -338,7 +338,7 @@ spec:
 
     ewc-tf-module-openstack-security-group:
       name: "ewc-tf-module-openstack-security-group"
-      version: "1.0.0"
+      version: "1.0.1"
       description: |
         > 💡 The module supports complex rule sets, such as those required to create a subnet security group for IPA services (i.e. Kerberos, LDAP and DNS).
 
@@ -363,7 +363,7 @@ spec:
               protocol         = "tcp"
               port_range_min   = 80
               port_range_max   = 80
-              remote_ip_prefix = "0.0.0.0/0"
+              remote_ip_prefix = "10.0.0.0/0"
             },
             {
               direction        = "ingress"
@@ -371,7 +371,7 @@ spec:
               protocol         = "udp"
               port_range_min   = 123
               port_range_max   = 123
-              remote_ip_prefix = "0.0.0.0/0"
+              remote_ip_prefix = "10.0.0.0/0"
             },
             {
               direction        = "ingress"
@@ -379,7 +379,7 @@ spec:
               protocol         = "tcp"
               port_range_min   = 88
               port_range_max   = 88
-              remote_ip_prefix = "0.0.0.0/0"
+              remote_ip_prefix = "10.0.0.0/0"
             },
             {
               direction        = "ingress"
@@ -387,7 +387,7 @@ spec:
               protocol         = "udp"
               port_range_min   = 88
               port_range_max   = 88
-              remote_ip_prefix = "0.0.0.0/0"
+              remote_ip_prefix = "10.0.0.0/0"
             },
             {
               direction        = "ingress"
@@ -395,7 +395,7 @@ spec:
               protocol         = "tcp"
               port_range_min   = 53
               port_range_max   = 53
-              remote_ip_prefix = "0.0.0.0/0"
+              remote_ip_prefix = "10.0.0.0/0"
             },
             {
               direction        = "ingress"
@@ -403,7 +403,7 @@ spec:
               protocol         = "udp"
               port_range_min   = 53
               port_range_max   = 53
-              remote_ip_prefix = "0.0.0.0/0"
+              remote_ip_prefix = "10.0.0.0/0"
             },
             {
               direction        = "ingress"
@@ -411,7 +411,7 @@ spec:
               protocol         = "tcp"
               port_range_min   = 389
               port_range_max   = 389
-              remote_ip_prefix = "0.0.0.0/0"
+              remote_ip_prefix = "10.0.0.0/0"
             },
             {
               direction        = "ingress"
@@ -427,7 +427,7 @@ spec:
               protocol         = "tcp"
               port_range_min   = 636
               port_range_max   = 636
-              remote_ip_prefix = "0.0.0.0/0"
+              remote_ip_prefix = "10.0.0.0/0"
             },
             {
               direction        = "ingress"
@@ -435,7 +435,7 @@ spec:
               protocol         = "tcp"
               port_range_min   = 464
               port_range_max   = 464
-              remote_ip_prefix = "0.0.0.0/0"
+              remote_ip_prefix = "10.0.0.0/0"
             },
             {
               direction        = "ingress"
@@ -443,7 +443,7 @@ spec:
               protocol         = "udp"
               port_range_min   = 464
               port_range_max   = 464
-              remote_ip_prefix = "0.0.0.0/0"
+              remote_ip_prefix = "10.0.0.0/0"
             },
             {
               direction        = "ingress"
@@ -451,7 +451,7 @@ spec:
               protocol         = "tcp"
               port_range_min   = 443
               port_range_max   = 443
-              remote_ip_prefix = "0.0.0.0/0"
+              remote_ip_prefix = "10.0.0.0/0"
             }
           ]
 
@@ -469,7 +469,7 @@ spec:
         |------|-------------|------|---------|:--------:|
         | `security_group_name` | Name of the security group. Example: `ipa` | `string` | n/a | yes |
         | `security_group_description` | Description of the security group | `string` | n/a | no |
-        | `security_group_rules` | List of security group rules | `list(object({direction = string, ether_type = string, protocol = string, port_range_min = number, port_range_max = number, remote_ip_prefix = string}))` | `[]` | no |
+        | `security_group_rules` | List of security group rules | `list(object({direction = string, ether_type = string, protocol = string, port_range_min = number, port_range_max = number, remote_ip_prefix = string}))` | n/a | yes |
         | `tags` | Map of tags to assign to the security group | `map(string)` | `{}` | no |
 
         ### Security Group Rules Input Structure
@@ -481,7 +481,7 @@ spec:
         - `protocol`: The protocol (e.g., `tcp`, `udp`, `icmp`, or `null` for any).
         - `port_range_min`: The minimum port number (1-65535, or `null` for protocols like `icmp`).
         - `port_range_max`: The maximum port number (1-65535, or `null` for protocols like `icmp`).
-        - `remote_ip_prefix`: The remote IP prefix in CIDR notation (e.g., `0.0.0.0/0`).
+        - `remote_ip_prefix`: The remote IP prefix in CIDR notation (e.g., `10.0.0.0/0`).
 
         ## SW Bill of Materials (SBoM)
         Third-party components used in the working environment.
@@ -498,8 +498,8 @@ spec:
         | `security_group_id` | ID of the created security group |
         | `security_group_name` | Name of the created security group |
         | `security_group_rules` | List of created security group rule IDs |
- 
-      home: https://github.com/ewcloud/ewc-tf-module-openstack-security-group/tree/1.0.0
+
+      home: https://github.com/ewcloud/ewc-tf-module-openstack-security-group/tree/1.0.1
       sources:
         - https://github.com/ewcloud/ewc-tf-module-openstack-security-group.git
       maintainers:
@@ -515,7 +515,7 @@ spec:
         licenseType: "MIT License"
       displayName: OpenStack Security Group
       summary: Automates the creation of EWC security groups and their rules, or update and teardown of existing ones, via Terraform.
-      license: https://github.com/ewcloud/ewc-tf-module-openstack-security-group/blob/1.0.0/LICENSE
+      license: https://github.com/ewcloud/ewc-tf-module-openstack-security-group/blob/1.0.1/LICENSE
       published: true
 
     ecmwf-aifs-single-mse:


### PR DESCRIPTION
Hello @pacospace, 
Just a boring patch here, to share an example usage with more secure default source IP addresses and remove the option for running the Item without specifying security rules (as in 99.9% of the cases, users should no create a security group without rules).