### PR TITLE
Optional item test exclusion

### DIFF
--- a/.github/scripts/orchestrator/main.py
+++ b/.github/scripts/orchestrator/main.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python3
 # Orchestration for downstream concurrent test deployment workflows.
 
-# Filtering Methods
-# Items to be tested are filtered by a combination (logical AND operation) of the following conditions:
+# Inclusion Methods
+# Items to be tested are filtered by a combination of the following conditions (logical AND):
 # 1. the value of the `ITEM_TECHNOLOGY_ANNOTATIONS`env var is equivalent to the `annotations[].technology` attribute values
 # 2. the value of the `ITEM_OTHERS_ANNOTATIONS`env var is equivalent of the `annotations[].others` attribute values
 # 3. the presence of the `values` attribute in the Item's metadata
-# 4. (optional) the `items.<item key>.name` attribute values is in the list of names in the `ITEM_NAMES`env var, if set
+# 4. the `items.<item key>.name` attribute values is in the list of names in the `ITEM_NAMES`env var (optional)
+#
+# Exclusion Methods
+# Items to NOT be tested can be specified by:
+# 1. the `items.<item key>.name` attribute values is in the list of names in the `EXCLUDED+ITEM_NAMES`env var (optional).
+# If set, overrides all inclusion criteria for the specified items.
 #
 # Deployment Methods
 # Tests are dispatched according to the metadata annotations `others`. The deployment options include Items' native (Ansible CLI,
@@ -38,6 +43,7 @@ from yaml import safe_load as yaml_safe_load
 GH_API_TOKEN = environ["GH_API_TOKEN"]
 GH_DOWNSTREAM_WORKFLOW_FILE = environ["GH_DOWNSTREAM_WORKFLOW_FILE"]
 ITEM_NAMES = getenv("ITEM_NAMES", "")
+EXCLUDED_ITEM_NAMES = getenv("EXCLUDED_ITEM_NAMES", "")
 ITEM_TECHNOLOGY_ANNOTATIONS = getenv("ITEM_TECHNOLOGY_ANNOTATIONS", "Ansible Playbook")
 ITEM_OTHERS_ANNOTATIONS = getenv("ITEM_OTHERS_ANNOTATIONS", "Deployable")
 POLLING_INTERVAL_SECONDS = int(environ["POLLING_INTERVAL_SECONDS"])
@@ -121,6 +127,10 @@ def read_spec_items() -> dict:
         filtered_item_names = set(item_name.strip() for item_name in ITEM_NAMES.split(","))
         print(f"main thread - Reading Items with names: {filtered_item_names}", flush=True)
 
+    if EXCLUDED_ITEM_NAMES:
+        excluded_item_names = set(item_name.strip() for item_name in EXCLUDED_ITEM_NAMES.split(","))
+        print(f"main thread - Excluding Items with names: {excluded_item_names}", flush=True)
+
     filtered_item_technology_annotations = set(
         technology_annotation.strip() for technology_annotation in ITEM_TECHNOLOGY_ANNOTATIONS.split(",")
     )
@@ -139,6 +149,9 @@ def read_spec_items() -> dict:
 
         name = item.get("name")
         if ITEM_NAMES and name not in filtered_item_names:
+            continue
+
+        if EXCLUDED_ITEM_NAMES and name in excluded_item_names:
             continue
 
         values = item.get("values", {})

--- a/.github/workflows/test-deployment-ansible-ecmwf.yml
+++ b/.github/workflows/test-deployment-ansible-ecmwf.yml
@@ -8,6 +8,11 @@ on:
         required: false
         type: string
 
+      excluded-item-names:
+        description: Optional list of item names to exclude from the test (comma-separated). If set, overrides all inclusion criteria for the specified items.
+        required: false
+        type: string
+
       polling-interval-seconds:
         description: Polling interval in seconds, for querying downstream status
         required: true
@@ -53,6 +58,7 @@ jobs:
         env:
           GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
           ITEM_NAMES: ${{ inputs.item-names }}
+          EXCLUDED_ITEM_NAMES: ${{ inputs.excluded-item-names }}
           ITEM_TECHNOLOGY_ANNOTATIONS: "Ansible Playbook"
           ITEM_OTHERS_ANNOTATIONS: "Deployable"
           POLLING_INTERVAL_SECONDS: ${{ inputs.polling-interval-seconds }}

--- a/.github/workflows/test-deployment-ansible-eumetsat.yml
+++ b/.github/workflows/test-deployment-ansible-eumetsat.yml
@@ -8,6 +8,11 @@ on:
         required: false
         type: string
 
+      excluded-item-names:
+        description: Optional list of item names to exclude from the test (comma-separated). If set, overrides all inclusion criteria for the specified items.
+        required: false
+        type: string
+
       polling-interval-seconds:
         description: Polling interval in seconds, for querying downstream status
         required: true
@@ -53,6 +58,7 @@ jobs:
         env:
           GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
           ITEM_NAMES: ${{ inputs.item-names }}
+          EXCLUDED_ITEM_NAMES: ${{ inputs.excluded-item-names }}
           ITEM_TECHNOLOGY_ANNOTATIONS: "Ansible Playbook"
           ITEM_OTHERS_ANNOTATIONS: "Deployable"
           POLLING_INTERVAL_SECONDS: ${{ inputs.polling-interval-seconds }}

--- a/.github/workflows/test-deployment-ansible-via-ewccli-ecmwf.yml
+++ b/.github/workflows/test-deployment-ansible-via-ewccli-ecmwf.yml
@@ -8,6 +8,11 @@ on:
         required: false
         type: string
 
+      excluded-item-names:
+        description: Optional list of item names to exclude from the test (comma-separated). If set, overrides all inclusion criteria for the specified items.
+        required: false
+        type: string
+
       polling-interval-seconds:
         description: Polling interval in seconds, for querying downstream status
         required: true
@@ -53,6 +58,7 @@ jobs:
         env:
           GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
           ITEM_NAMES: ${{ inputs.item-names }}
+          EXCLUDED_ITEM_NAMES: ${{ inputs.excluded-item-names }}
           ITEM_TECHNOLOGY_ANNOTATIONS: "Ansible Playbook"
           ITEM_OTHERS_ANNOTATIONS: "Deployable,EWCCLI-compatible"
           POLLING_INTERVAL_SECONDS: ${{ inputs.polling-interval-seconds }}

--- a/.github/workflows/test-deployment-ansible-via-ewccli-eumetsat.yml
+++ b/.github/workflows/test-deployment-ansible-via-ewccli-eumetsat.yml
@@ -8,6 +8,11 @@ on:
         required: false
         type: string
 
+      excluded-item-names:
+        description: Optional list of item names to exclude from the test (comma-separated). If set, overrides all inclusion criteria for the specified items.
+        required: false
+        type: string
+
       polling-interval-seconds:
         description: Polling interval in seconds, for querying downstream status
         required: true
@@ -53,6 +58,7 @@ jobs:
         env:
           GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
           ITEM_NAMES: ${{ inputs.item-names }}
+          EXCLUDED_ITEM_NAMES: ${{ inputs.excluded-item-names }}
           ITEM_TECHNOLOGY_ANNOTATIONS: "Ansible Playbook"
           ITEM_OTHERS_ANNOTATIONS: "Deployable,EWCCLI-compatible"
           POLLING_INTERVAL_SECONDS: ${{ inputs.polling-interval-seconds }}


### PR DESCRIPTION
Hello @pacospace ,

This is an unplanned yet now obvious feature. 

**What's new**
 * All workflows allow now not just item inclusion by name but also item exclusion by name.

**Technical details**
As you know, there are Item with inputs for which reasonable defaults cannot be added to the catalog metadata (e.i. passwords, tenant names, site-specific resource names, etc). 
To prevent alert fatigue when running Deployment Test, it will be ideal to exclude Item which we know will always fail the catalog-centric tests.