### PR TITLE
No xcube-viewer-flavour in PR-triggered Deployment Test via EWCCLI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -156,6 +156,7 @@ jobs:
           ITEM_OTHERS_ANNOTATIONS: "Deployable,EWCCLI-compatible"
           GH_DOWNSTREAM_WORKFLOW_FILE: "test-deployment-ansible-ecmwf.yml"
           TOTAL_TIMEOUT_MINUTES: 190 # Must be smaller than jobs.orchestrate.timeout-minutes
+          EXCLUDED_ITEM_NAMES: "xcube-viewer-flavour"
 
   test-deploy-ansible-eumetsat-via-ewccli:
     name: Ansible Playbook Testing (via EWCCLI) on EUMETSAT
@@ -193,3 +194,4 @@ jobs:
           ITEM_OTHERS_ANNOTATIONS: "Deployable,EWCCLI-compatible"
           GH_DOWNSTREAM_WORKFLOW_FILE: "test-deployment-ansible-eumetsat.yml"
           TOTAL_TIMEOUT_MINUTES: 290 # Must be smaller than jobs.orchestrate.timeout-minutes
+          EXCLUDED_ITEM_NAMES: "xcube-viewer-flavour"


### PR DESCRIPTION
> **NOTE**: Relates to https://github.com/ewcloud/ewc-community-hub/pull/66

Hello @pacospace ,

As discussed, the `xcube-viewer-flavour` Item is bound to fail every catalog-centric deployment test triggered upon a PR opening.
This is because the Item includes inputs for which we currently cannot provide reasonable defaults as part of the calalog metadata, namely:
1. `tenant_name`
2. `federee`

As such, we explicitly excluded it from said test until, at least until those inputs can be automatically populated by the EWCCLI or inferred form the DNS records by the Item's inner workings.

**Motivation**

This is done to prevent the recurrent failures of CI from breaking trust in the PR review process. In other words, we should avoid  false negatives from diluting the quality of the reports we get from catalog-centric deployment tests.
