### PR TITLE
No eumetcast-terrestrial-amt-flavour in PR-triggered Deployment Test via EWCCLI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -156,7 +156,7 @@ jobs:
           ITEM_OTHERS_ANNOTATIONS: "Deployable,EWCCLI-compatible"
           GH_DOWNSTREAM_WORKFLOW_FILE: "test-deployment-ansible-ecmwf.yml"
           TOTAL_TIMEOUT_MINUTES: 190 # Must be smaller than jobs.orchestrate.timeout-minutes
-          EXCLUDED_ITEM_NAMES: "xcube-viewer-flavour"
+          EXCLUDED_ITEM_NAMES: "xcube-viewer-flavour,eumetcast-terrestrial-amt-flavour"
 
   test-deploy-ansible-eumetsat-via-ewccli:
     name: Ansible Playbook Testing (via EWCCLI) on EUMETSAT
@@ -194,4 +194,4 @@ jobs:
           ITEM_OTHERS_ANNOTATIONS: "Deployable,EWCCLI-compatible"
           GH_DOWNSTREAM_WORKFLOW_FILE: "test-deployment-ansible-eumetsat.yml"
           TOTAL_TIMEOUT_MINUTES: 290 # Must be smaller than jobs.orchestrate.timeout-minutes
-          EXCLUDED_ITEM_NAMES: "xcube-viewer-flavour"
+          EXCLUDED_ITEM_NAMES: "xcube-viewer-flavour,eumetcast-terrestrial-amt-flavour"


### PR DESCRIPTION
The new Item, index by https://github.com/ewcloud/ewc-community-hub/pull/77 contains user-specific inputs (credentials) for which no reasonable default can be currently included on the catalog. This implies any catalog-centric test of this Item is bound to fail due to missing required inputs. 