### PR TITLE
Bump pytroll processing version

### DIFF
--- a/items.yaml
+++ b/items.yaml
@@ -3371,7 +3371,7 @@ spec:
 
     pytroll-processing:
       name: "pytroll-processing"
-      version: "0.1.0"
+      version: "0.1.1"
       ewccli:
         pathToMainFile: satellite-data-processing-main.yaml
       description: |
@@ -3479,7 +3479,7 @@ spec:
         ansible-playbook -i inventory path/to/playbook/filename.yaml -e "satellite_data_type=seviri"
         ```
 
-      home: https://github.com/nordsat/ewc-playbooks/tree/0.1.0
+      home: https://github.com/nordsat/ewc-playbooks/tree/0.1.1
       sources:
         - https://github.com/nordsat/ewc-playbooks.git
       maintainers:
@@ -3494,7 +3494,7 @@ spec:
         others: "Deployable,EWCCLI-compatible"
       displayName: Pytroll Processing
       summary: Playbooks to install pytroll processing and wms in the EWC.
-      license: https://github.com/nordsat/ewc-playbooks/blob/0.1.0/LICENSE
+      license: https://github.com/nordsat/ewc-playbooks/blob/0.1.1/LICENSE
       published: true
 
     remote-desktop-flavour:

--- a/items.yaml
+++ b/items.yaml
@@ -3374,6 +3374,8 @@ spec:
       version: "0.1.1"
       ewccli:
         pathToMainFile: satellite-data-processing-main.yaml
+      values:
+        pathToMainFile: satellite-data-processing-main.yaml
       description: |
         Playbooks to install and configure Pytroll-based satellite data processing pipelines and optionally a WMS server. These playbooks are used in the European Weather Cloud (EWC) environment.
 

--- a/items.yaml
+++ b/items.yaml
@@ -3371,7 +3371,7 @@ spec:
 
     pytroll-processing:
       name: "pytroll-processing"
-      version: "0.1.1"
+      version: "0.1.2"
       ewccli:
         pathToMainFile: satellite-data-processing-main.yaml
       values:
@@ -3481,7 +3481,7 @@ spec:
         ansible-playbook -i inventory path/to/playbook/filename.yaml -e "satellite_data_type=seviri"
         ```
 
-      home: https://github.com/nordsat/ewc-playbooks/tree/0.1.1
+      home: https://github.com/nordsat/ewc-playbooks/tree/0.1.2
       sources:
         - https://github.com/nordsat/ewc-playbooks.git
       maintainers:
@@ -3496,7 +3496,7 @@ spec:
         others: "Deployable,EWCCLI-compatible"
       displayName: Pytroll Processing
       summary: Playbooks to install pytroll processing and wms in the EWC.
-      license: https://github.com/nordsat/ewc-playbooks/blob/0.1.1/LICENSE
+      license: https://github.com/nordsat/ewc-playbooks/blob/0.1.2/LICENSE
       published: true
 
     remote-desktop-flavour:


### PR DESCRIPTION
> **IMPORTANT**: Please be ware that the, although a tag [0.1.2](https://github.com/nordsat/ewc-playbooks/releases/tag/0.1.2) has already been created on the home repository of the Item, it does not including the patch you submitted. The PR https://github.com/nordsat/ewc-playbooks/pull/17  is still pending for merge!

Hello @pacospace,

This is the provisional PR you requested, to index the new fix that will be introduced with https://github.com/nordsat/ewc-playbooks/pull/17.

