### PR TITLE
Introduce shortnamed images in item metadata defaults

### DIFF
--- a/items.yaml
+++ b/items.yaml
@@ -46,7 +46,7 @@ spec:
         pathToMainFile: playbooks/ai-models/ai-models.yml
       values:
         pathToMainFile: playbooks/ai-models/ai-models.yml
-        osImageName: ubuntu-24.04-20250604102601
+        osImageName: Ubuntu-24.04
         ansibleUser: ubuntu
       home: https://github.com/ewcloud/ewc-ecmwf-ai-stacks
       sources:
@@ -655,7 +655,7 @@ spec:
         pathToMainFile: playbooks/aifs-single-mse/aifs-single-mse.yml
       values:
         pathToMainFile: playbooks/aifs-single-mse/aifs-single-mse.yml
-        osImageName: ubuntu-24.04-20250604102601
+        osImageName: Ubuntu-24.04
         ansibleUser: ubuntu
       home: https://github.com/ewcloud/ewc-ecmwf-ai-stacks
       sources:
@@ -724,7 +724,7 @@ spec:
         pathToMainFile: playbooks/aifs-ens-crps/aifs-ens-crps.yml
       values:
         pathToMainFile: playbooks/aifs-ens-crps/aifs-ens-crps.yml
-        osImageName: ubuntu-24.04-20250604102601
+        osImageName: Ubuntu-24.04
         ansibleUser: ubuntu
       home: https://github.com/ewcloud/ewc-ecmwf-ai-stacks
       sources:
@@ -752,7 +752,7 @@ spec:
         pathToMainFile: anemoi.yml
       values:
         pathToMainFile: anemoi.yml
-        osImageName: ubuntu-24.04-20250604102601
+        osImageName: Ubuntu-24.04
         ansibleUser: ubuntu
       description: |
         Create a conda environment with the Anemoi framework for weather forecasting based on machine learning and associated software stack.
@@ -869,7 +869,7 @@ spec:
         pathToMainFile: playbooks/ecmwf-data-flavour/ecmwf-data-flavour.yml
         pathToRequirementsFile: requirements.yml
       values:
-        osImageName: ubuntu-24.04-20250604102601
+        osImageName: Ubuntu-24.04
         ansibleUser: ubuntu
         inputSpec:
           - name: reboot_if_required
@@ -918,7 +918,7 @@ spec:
       ewccli:
         pathToRequirementsFile: playbooks/eumetcast-terrestrial-amt-flavour/requirements.yml
         pathToMainFile: playbooks/eumetcast-terrestrial-amt-flavour/eumetcast-terrestrial-amt-flavour.yml
-        defaultImageName: Ubuntu-22.04-20251007115800
+        defaultImageName: Ubuntu-22.04
         inputs:
           - name: tellicast_license_user_name
             description: Tellicast license user identifier, equivalent to your EUMETSAT User Portal username.
@@ -927,7 +927,7 @@ spec:
             description: Tellicast license activation key (i.e. the user key you obtained via from EUMETSAT Helpdesk).
             type: str
       values:
-        osImageName: Ubuntu-22.04-20251007115800
+        osImageName: Ubuntu-22.04
         ansibleUser: ubuntu
         pathToRequirementsFile: playbooks/eumetcast-terrestrial-amt-flavour/requirements.yml
         pathToMainFile: playbooks/eumetcast-terrestrial-amt-flavour/eumetcast-terrestrial-amt-flavour.yml
@@ -1117,7 +1117,7 @@ spec:
       ewccli:
         pathToRequirementsFile: playbooks/eumetsat-s3-mount-flavour/requirements.yml
         pathToMainFile: playbooks/eumetsat-s3-mount-flavour/eumetsat-s3-mount-flavour.yml
-        defaultImageName: Ubuntu-22.04-20251007115800
+        defaultImageName: Ubuntu-22.04
         inputs:
           - name: vfs_cache_mode
             description: Cache mode
@@ -1128,7 +1128,7 @@ spec:
             type: str
             default: 512Mi
       values:
-        osImageName: Ubuntu-22.04-20251007115800
+        osImageName: Ubuntu-22.04
         ansibleUser: ubuntu
         pathToRequirementsFile: playbooks/eumetsat-s3-mount-flavour/requirements.yml
         pathToMainFile: playbooks/eumetsat-s3-mount-flavour/eumetsat-s3-mount-flavour.yml
@@ -1288,7 +1288,7 @@ spec:
       ewccli:
         pathToRequirementsFile: playbooks/eumetsat-data-tailor-flavour/requirements.yml
         pathToMainFile: playbooks/eumetsat-data-tailor-flavour/eumetsat-data-tailor-flavour.yml
-        defaultImageName: ubuntu-24.04-20250604102601
+        defaultImageName: Ubuntu-24.04
         inputs:
           - name: data_tailor_env_wipe
             description: flag to delete existing conda environment where data tailor was previously installed. Only yes will be accepted to approve
@@ -1315,7 +1315,7 @@ spec:
             type: str
             default: "root"
       values:
-        osImageName: ubuntu-24.04-20250604102601
+        osImageName: Ubuntu-24.04
         ansibleUser: ubuntu
         pathToRequirementsFile: playbooks/eumetsat-data-tailor-flavour/requirements.yml
         pathToMainFile: playbooks/eumetsat-data-tailor-flavour/eumetsat-data-tailor-flavour.yml
@@ -1819,7 +1819,7 @@ spec:
         - https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning.git
       summary: Configures an existing VM as a high-performance load balancer, enhancing application speed, security, and scalability with easy management for TCP and HTTP workloads.
       values:
-        osImageName: ubuntu-24.04-20250604102601
+        osImageName: Ubuntu-24.04
         ansibleUser: ubuntu
         inputSpec:
           - name: os_security_group_name
@@ -2678,7 +2678,7 @@ spec:
       name: "ipa-server-flavour"
       version: "1.8.0"
       ewccli:
-        defaultImageName: Rocky-9.6-20251107141503
+        defaultImageName: Rocky-9
         pathToRequirementsFile: playbooks/ipa-server-flavour/requirements.yml
         pathToMainFile: playbooks/ipa-server-flavour/ipa-server-flavour.yml
         inputs:
@@ -2709,7 +2709,7 @@ spec:
         defaultSecurityGroups:
           - ipa
       values:
-        osImageName: Rocky-9.6-20251107141503
+        osImageName: Rocky-9
         ansibleUser: cloud-user
         pathToRequirementsFile: playbooks/ipa-server-flavour/requirements.yml
         pathToMainFile: playbooks/ipa-server-flavour/ipa-server-flavour.yml
@@ -3177,7 +3177,7 @@ spec:
         externalIP: true
         checkDNS: true
       values:
-        osImageName: ubuntu-24.04-20250604102601
+        osImageName: Ubuntu-24.04
         ansibleUser: ubuntu
         pathToMainFile: playbooks/jupyterhub-flavour/jupyterhub-flavour.yml
         pathToRequirementsFile: requirements.yml
@@ -3245,7 +3245,7 @@ spec:
       ewccli:
         pathToMainFile: ml-basic.yml
       values:
-        osImageName: ubuntu-24.04-20250604102601
+        osImageName: Ubuntu-24.04
         ansibleUser: ubuntu
         pathToMainFile: ml-basic.yml
       description: |
@@ -3463,7 +3463,7 @@ spec:
             description: "OpenStack security group containing all firewall rules required for Nginx Proxy Manager operation"
             type: str
             default: nginx-proxy-manager
-        osImageName: ubuntu-24.04-20250604102601
+        osImageName: Ubuntu-24.04
         ansibleUser: ubuntu
         pathToMainFile: playbooks/nginx-proxy-manager-flavour/nginx-proxy-manager-flavour.yml
         pathToRequirementsFile: playbooks/nginx-proxy-manager-flavour/requirements.yml
@@ -4087,7 +4087,7 @@ spec:
       name: "remote-desktop-flavour"
       version: "1.8.0"
       ewccli:
-        defaultImageName: Rocky-9.6-20251107141503
+        defaultImageName: Rocky-9
         pathToRequirementsFile: playbooks/remote-desktop-flavour/requirements.yml
         pathToMainFile: playbooks/remote-desktop-flavour/remote-desktop-flavour.yml
         inputs:
@@ -4096,7 +4096,7 @@ spec:
             type: Optional[List[str]]
             default: null
       values:
-        osImageName: Rocky-9.6-20251107141503
+        osImageName: Rocky-9
         ansibleUser: cloud-user
         pathToRequirementsFile: playbooks/remote-desktop-flavour/requirements.yml
         pathToMainFile: playbooks/remote-desktop-flavour/remote-desktop-flavour.yml
@@ -4456,7 +4456,7 @@ spec:
       name: "ssh-bastion-flavour"
       version: "1.8.0"
       ewccli:
-        defaultImageName: Rocky-9.6-20251107141503
+        defaultImageName: Rocky-9
         pathToRequirementsFile: playbooks/ssh-bastion-flavour/requirements.yml
         pathToMainFile: playbooks/ssh-bastion-flavour/ssh-bastion-flavour.yml
         inputs:
@@ -4466,7 +4466,7 @@ spec:
             default: null
         externalIP: true
       values:
-        osImageName: Rocky-9.6-20251107141503
+        osImageName: Rocky-9
         ansibleUser: cloud-user
         pathToRequirementsFile: playbooks/ssh-bastion-flavour/requirements.yml
         pathToMainFile: playbooks/ssh-bastion-flavour/ssh-bastion-flavour.yml
@@ -4785,7 +4785,7 @@ spec:
       name: "xcube-viewer-flavour"
       version: "1.8.0"
       ewccli:
-        defaultImageName: ubuntu-24.04-2025060410260
+        defaultImageName: ubuntu-24.04
         defaultSecurityGroups: [ssh-http-https]
         pathToRequirementsFile: playbooks/xcube-viewer-flavour/requirements.yml
         pathToMainFile: playbooks/xcube-viewer-flavour/xcube-viewer-flavour.yml
@@ -4827,7 +4827,7 @@ spec:
         externalIP: true
         checkDNS: true
       values:
-        osImageName: ubuntu-24.04-20250604102601
+        osImageName: ubuntu-24.04
         ansibleUser: ubuntu
         pathToRequirementsFile: playbooks/xcube-viewer-flavour/requirements.yml
         pathToMainFile: playbooks/xcube-viewer-flavour/xcube-viewer-flavour.yml

--- a/items.yaml
+++ b/items.yaml
@@ -44,6 +44,7 @@ spec:
 
       ewccli:
         pathToMainFile: playbooks/ai-models/ai-models.yml
+        defaultImageName: Ubuntu-24.04
       values:
         pathToMainFile: playbooks/ai-models/ai-models.yml
         osImageName: Ubuntu-24.04
@@ -653,6 +654,7 @@ spec:
 
       ewccli:
         pathToMainFile: playbooks/aifs-single-mse/aifs-single-mse.yml
+        defaultImageName: Ubuntu-24.04
       values:
         pathToMainFile: playbooks/aifs-single-mse/aifs-single-mse.yml
         osImageName: Ubuntu-24.04
@@ -722,6 +724,7 @@ spec:
 
       ewccli:
         pathToMainFile: playbooks/aifs-ens-crps/aifs-ens-crps.yml
+        defaultImageName: Ubuntu-24.04
       values:
         pathToMainFile: playbooks/aifs-ens-crps/aifs-ens-crps.yml
         osImageName: Ubuntu-24.04
@@ -750,6 +753,7 @@ spec:
       version: "1.0.1"
       ewccli:
         pathToMainFile: anemoi.yml
+        defaultImageName: Ubuntu-24.04
       values:
         pathToMainFile: anemoi.yml
         osImageName: Ubuntu-24.04
@@ -841,6 +845,7 @@ spec:
 
       displayName: ECMWF Data Flavour
       ewccli:
+        defaultImageName: Ubuntu-24.04
         inputs:
           - name: reboot_if_required
             default: true
@@ -4785,7 +4790,7 @@ spec:
       name: "xcube-viewer-flavour"
       version: "1.8.0"
       ewccli:
-        defaultImageName: ubuntu-24.04
+        defaultImageName: Ubuntu-24.04
         defaultSecurityGroups: [ssh-http-https]
         pathToRequirementsFile: playbooks/xcube-viewer-flavour/requirements.yml
         pathToMainFile: playbooks/xcube-viewer-flavour/xcube-viewer-flavour.yml
@@ -4827,7 +4832,7 @@ spec:
         externalIP: true
         checkDNS: true
       values:
-        osImageName: ubuntu-24.04
+        osImageName: Ubuntu-24.04
         ansibleUser: ubuntu
         pathToRequirementsFile: playbooks/xcube-viewer-flavour/requirements.yml
         pathToMainFile: playbooks/xcube-viewer-flavour/xcube-viewer-flavour.yml

--- a/items.yaml
+++ b/items.yaml
@@ -1824,7 +1824,7 @@ spec:
         - https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning.git
       summary: Configures an existing VM as a high-performance load balancer, enhancing application speed, security, and scalability with easy management for TCP and HTTP workloads.
       values:
-        osImageName: Ubuntu-24.04
+        osImageName: Ubuntu-24.04-20260519071420
         ansibleUser: ubuntu
         inputSpec:
           - name: os_security_group_name
@@ -3468,7 +3468,7 @@ spec:
             description: "OpenStack security group containing all firewall rules required for Nginx Proxy Manager operation"
             type: str
             default: nginx-proxy-manager
-        osImageName: Ubuntu-24.04
+        osImageName: Ubuntu-24.04-20260519071420
         ansibleUser: ubuntu
         pathToMainFile: playbooks/nginx-proxy-manager-flavour/nginx-proxy-manager-flavour.yml
         pathToRequirementsFile: playbooks/nginx-proxy-manager-flavour/requirements.yml


### PR DESCRIPTION
Hello @pacospace,

This PR re-introduces/bundles a series of commits that were first added on mid July 2026, and which bypassed the metadata linting and e2e testing automation. 

For EWCCLI-compatible Ansible Items, the commits in question replace OS image names, which are public on the [EWC Knowledge Base](https://confluence.ecmwf.int/spaces/EWCLOUDKB/pages/414272933/EWC+Virtual+Images+Available), with shorter versions that the EWCCLI can now parse and map to whichever the latest image version of the specified family is.

Additionally, for other Ansible Items that are not supported by the EWCCLI, the OS image full name was updated to the latest one, given the minimal subset of Images ported into the new EUMETSAT cloud.

You can find a full e2e test reports by scrolling down the summary page of [run 30240602894](https://github.com/ewcloud/ewc-community-hub/actions/runs/30240602894).