### PR TITLE
Bump EUMETSAT Items bundle version to 1.9.0

### DIFF
--- a/items.yaml
+++ b/items.yaml
@@ -1867,7 +1867,7 @@ spec:
         ## Prerequisites
 
         * Install [git](https://git-scm.com/downloads) (version 2.0 or higher )
-        * Install [python](https://www.python.org/downloads) (version 3.9 or higher) 
+        * Install [python](https://www.python.org/downloads) (version 3.9 or higher)
         * Install [python-openstackclient](https://pypi.org/project/python-openstackclient) (version 8.0 or higher)
         * Install [ansible](https://pypi.org/project/ansible) (version 2.15 or higher)
         * Install [terraform](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+-+IaC+via+Terraform+and+OpenTofu#EWCIaCviaTerraformandOpenTofu-InstallationoftheCLI) (version 1.0 or higher)
@@ -1879,7 +1879,7 @@ spec:
         > ⚠️ Only RockyLinux versions 9 or 8 are supported due
         to constrains imposed by [dependencies](#dependencies).
 
-        > 💡 VM plans with at least 4GB of RAM is recommended for successful setup and stable operation 
+        > 💡 VM plans with at least 4GB of RAM is recommended for successful setup and stable operation
 
         >⛔ Execution of this template can potentially affect DNS resolution on existing VMs within your subnet. To prevent issues, enroll them to the new IPA server via the
         [IPA Client Enroll Flavour](https://europeanweather.cloud/community-hub/ipa-client-enroll-flavour)
@@ -2418,7 +2418,7 @@ spec:
         ## Prerequisites
 
         * Install [git](https://git-scm.com/downloads) (version 2.0 or higher )
-        * Install [python](https://www.python.org/downloads) (version 3.9 or higher) 
+        * Install [python](https://www.python.org/downloads) (version 3.9 or higher)
         * Install [python-openstackclient](https://pypi.org/project/python-openstackclient) (version 8.0 or higher)
         * Install [ansible](https://pypi.org/project/ansible) (version 2.15 or higher)
         * Install [terraform](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+-+IaC+via+Terraform+and+OpenTofu#EWCIaCviaTerraformandOpenTofu-InstallationoftheCLI) (version 1.0 or higher)
@@ -2996,7 +2996,7 @@ spec:
         ## Prerequisites
 
         * Install [git](https://git-scm.com/downloads) (version 2.0 or higher )
-        * Install [python](https://www.python.org/downloads) (version 3.9 or higher) 
+        * Install [python](https://www.python.org/downloads) (version 3.9 or higher)
         * Install [python-openstackclient](https://pypi.org/project/python-openstackclient) (version 8.0 or higher)
         * Install [ansible](https://pypi.org/project/ansible) (version 2.15 or higher)
         * Install [terraform](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+-+IaC+via+Terraform+and+OpenTofu#EWCIaCviaTerraformandOpenTofu-InstallationoftheCLI) (version 1.0 or higher)
@@ -4327,7 +4327,7 @@ spec:
         ## Prerequisites
 
         * Install [git](https://git-scm.com/downloads) (version 2.0 or higher )
-        * Install [python](https://www.python.org/downloads) (version 3.9 or higher) 
+        * Install [python](https://www.python.org/downloads) (version 3.9 or higher)
         * Install [python-openstackclient](https://pypi.org/project/python-openstackclient) (version 8.0 or higher)
         * Install [ansible](https://pypi.org/project/ansible) (version 2.15 or higher)
         * Install [terraform](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+-+IaC+via+Terraform+and+OpenTofu#EWCIaCviaTerraformandOpenTofu-InstallationoftheCLI) (version 1.0 or higher)
@@ -4640,12 +4640,12 @@ spec:
       description: |
         >✅ This template can be safely applied from any local work environment, even running outside an EWC tenancy's private network.
 
-        The remote desktop is a regular RockyLinux instance equipped with [X2Go](https://wiki.x2go.org/doku.php).
-        It enables you to access a graphical desktop computer running in your remote
-        instance of choice, over a low bandwidth (or high bandwidth) connection.
-        This means that you can connect to it via the
-        [X2Go client](https://wiki.x2go.org/doku.php/doc:installation:x2goclient)
-        to enjoy a regular desktop user experience.
+        The [SSH](https://en.wikipedia.org/wiki/Secure_Shell) proxy or bastion server
+        is a barrier between your internal machines (without public or floating IPs)
+        and the public internet. With the SSH proxy, you'll have an extra layer of
+        security on top of your instances. It's equipped with
+        [Fail2ban](https://github.com/fail2ban/fail2ban),
+        intrusion prevention software designed to prevent brute-force attacks.
 
         This is a configuration template
         (i.e. an [Ansible Playbook](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks.html))
@@ -4663,11 +4663,10 @@ spec:
           instance from scratch
 
             OR
-          * If  `terraform.tfstate` file is found, leverages Terraform's out-of-the-box
-            functionality to update the instance referenced on it
-        * Configure the existing or newly provisioned instance such that it:
-          * Enables users to operate the remote hosts through a graphical desktop
-            (i.e. a [MATE desktop environment](https://mate-desktop.org/)), over a low or high bandwidth connection.
+          * If  `terraform.tfstate` file is found, leverages Terraform's out-of-the-box functionality to update the instance referenced on it
+        * Configure the existing or newly provisioned RockyLinux virtual machines (with
+        public IP address), as entrypoint for users who wish to reach private EWC networks
+        from the public internet via SSH.
 
         After successful provisioning, you can leverage Terraform's functionality to modify or delete individual components safely. Each will have its own `main.tf` definition and `terraform.tfstate` state file under the corresponding user-defined local directories.
 
@@ -4679,7 +4678,7 @@ spec:
         ## Prerequisites
 
         * Install [git](https://git-scm.com/downloads) (version 2.0 or higher )
-        * Install [python](https://www.python.org/downloads) (version 3.9 or higher) 
+        * Install [python](https://www.python.org/downloads) (version 3.9 or higher)
         * Install [python-openstackclient](https://pypi.org/project/python-openstackclient) (version 8.0 or higher)
         * Install [ansible](https://pypi.org/project/ansible) (version 2.15 or higher)
         * Install [terraform](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+-+IaC+via+Terraform+and+OpenTofu#EWCIaCviaTerraformandOpenTofu-InstallationoftheCLI) (version 1.0 or higher)
@@ -4702,7 +4701,7 @@ spec:
         #### 1.1. Change to the specific Item's subdirectory
 
         ```bash
-        cd ewc-ansible-playbook-flavours-and-provisioning/playbooks/remote-desktop-provisioning
+        cd ewc-ansible-playbook-flavours-and-provisioning/playbooks/ssh-bastion-provisioning
         ```
 
         #### 1.2. (Optional) Checkout an specific Item's version
@@ -4730,7 +4729,7 @@ spec:
         target EWC environment:
 
         ```bash
-        ansible-playbook remote-desktop-provisioning.yml
+        ansible-playbook ssh-bastion-provisioning.yml
         ```
 
         #### 3.2. Non-Interactive Mode
@@ -4746,54 +4745,35 @@ spec:
         ansible-playbook \
           -e '{
                 "ewc_provider":"eumetsat",
-                "remote_desktop_tf_project_path":"~/ewc/remote-desktop-1",
-                "remote_desktop_app_name":"remote",
-                "remote_desktop_instance_name":"desktop",
-                "remote_desktop_instance_index":1,
-                "remote_desktop_flavor_name":"4cpu-8gbmem",
-                "remote_desktop_image_name":"Rocky-9.7-20260519081947",
-                "remote_desktop_instance_has_fip":"no",
+                "ssh_bastion_tf_project_path":"~/ewc/ssh-bastion-1",
+                "ssh_bastion_app_name":"ssh",
+                "ssh_bastion_instance_name":"bastion",
+                "ssh_bastion_instance_index":1,
+                "ssh_bastion_flavor_name":"4cpu-8gbmem",
+                "ssh_bastion_image_name":"Rocky-9.7-20260519081947",
                 "public_keypair_name":"my-public-key-name",
                 "private_keypair_path":"~/.ssh/id_rsa",
                 "private_network_name":"private",
                 "security_group_name":"ssh"
             }' \
-          remote-desktop-provisioning.yml
+          ssh-bastion-provisioning.yml
         ```
-
-        ### 4. Install the local client and connect to your remote desktop
-        >⚠️ When configuring a connection, be sure to select "MATE" (instead of
-        "KDE" or any other options) in the `Session Type` drop-down list, towards the
-        bottom of the `Session` tab. This is required for the local client to correctly
-        communicate with your remote desktop.
-
-        Install the remote desktop client on Microsoft Window, Mac OS or Linux by
-        following the links on the [official X2Go installation page](https://wiki.x2go.org/doku.php/doc:installation:x2goclient). Then follow the [official X2Go client usage page](https://wiki.x2go.org/doku.php/doc:usage:x2goclient)
-        if you do not know how to configure a new session.
-
-        For a session creation
-        example, representative of a typical EWC environment, checkout the Remote
-        Desktop section of
-        [this official EWC documentation page](https://confluence.ecmwf.int/display/EWCLOUDKB/EUMETSAT+tenancy%3A+Default+setup).
-
-
         ## Inputs
 
         | Name | Description | Type | Default | Required |
         |------|-------------|------|---------|----------|
         | ewc_provider | your target EWC provider. Must match that the provider of your OpenStack application credentials. Valid input values are `ecmwf` or `eumetsat`. | `string` | `eumetsat` | yes |
-        | remote_desktop_tf_project_path | path to terraform working directory | `string` | `~/ewc/remote-desktop-1` | yes |
-        | remote_desktop_app_name | application name, used as prefix in the full instance name | `string` | `remote` | yes |
-        | remote_desktop_instance_name| name of the instance, used in the full instance name | `string` | `desktop` | yes |
-        | remote_desktop_instance_index | index or identifier for the instance, used as suffix in the full instance name | `number` | `1` | yes |
-        | remote_desktop_flavor_name | name the flavor to use for the instance. To learn about available options, checkout the [official EWC VM plans documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+VM+plans) | `string` | `4cpu-8gbmem` | yes |
-        | remote_desktop_image_name | name of the image to use for the instance. For complete information on  available options, see the [official EWC Images documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+Virtual+Images+Available) | `string` | `Rocky-9.7-20260519081947` | yes |
-        | remote_desktop_instance_has_fip | whether to assign a floating IP to the instance. Only `yes` will be accepted to approve | `string` | `no` | no |
+        | ssh_bastion_tf_project_path | path to terraform working directory | `string` | `~/ewc/ssh-bastion-1` | yes |
+        | ssh_bastion_app_name | application name, used as prefix in the full instance name  | `string` | `ssh` | yes |
+        | ssh_bastion_instance_name| name of the instance, used in the full instance name | `string` | `bastion` | yes |
+        | ssh_bastion_instance_index | index or identifier for the instance, used as suffix in the full instance name | `number` | `1` | yes |
+        | ssh_bastion_flavor_name | name the flavor to use for the instance. To learn about available options, checkout the [official EWC VM plans documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+VM+plans) | `string` | `4cpu-8gbmem` | yes |
+        | ssh_bastion_image_name | name of the image to use for the instance. For complete information on  available options, see the [official EWC Images documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+Virtual+Images+Available)  | `string` | `Rocky-9.7-20260519081947` | yes |
         | public_keypair_name | name of public keypair (stored in OpenStack) to be copied into the instance for remote SSH access | `string` | n/a | yes |
-        | private_keypair_path| path to the local private keypair to use for SSH access to the instance | `string` | `~/.ssh/id_rsa` | yes |
-        | private_networks_name | private network name to attach the instance to  | `string` | `private` | yes |
-        | security_group_name | security group name to apply to the instance | `string` | `ipa` | yes |
-        | fail2ban_whitelisted_ip_ranges | IPv4 ranges (in CIDR format) to be whitelisted in Fail2ban configuration. When in doubt, do not set. Example: `['10.0.0.0/24','192.168.1.0/24']` | `list(string)` | `null` | no |
+        | private_keypair_name | path to the local private keypair to use for SSH access to the instance  | `string` | `~/.ssh/id_rsa` | yes |
+        | private_network_name | private network name to attach the instance to  | `string` | `private` | yes |
+        | security_group_name | security group name to apply to the instance | `string` | `ssh` | yes |
+        | fail2ban_whitelisted_ip_ranges | IPv4 ranges (in CIDR format) to be whitelisted in Fail2ban configuration. Example: `['10.0.0.0/24','192.168.1.0/24']` | `list(string)` | `null` | no |
 
       home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.9.0/playbooks/ssh-bastion-provisioning
       sources:

--- a/items.yaml
+++ b/items.yaml
@@ -914,7 +914,7 @@ spec:
 
     eumetcast-terrestrial-amt-flavour:
       name: "eumetcast-terrestrial-amt-flavour"
-      version: "1.8.4"
+      version: "1.9.0"
       ewccli:
         pathToRequirementsFile: playbooks/eumetcast-terrestrial-amt-flavour/requirements.yml
         pathToMainFile: playbooks/eumetcast-terrestrial-amt-flavour/eumetcast-terrestrial-amt-flavour.yml
@@ -1092,7 +1092,7 @@ spec:
         | tellicast_license_user_name | Tellicast license user identifier, equivalent to your EUMETSAT User Portal username. | `string` | n/a | yes |
         | tellicast_license_user_key | Tellicast license activation key (i.e. the user key you obtained via from EUMETSAT Helpdesk). | `string` | n/a | yes |
 
-      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.8.4/playbooks/eumetcast-terrestrial-amt-flavour
+      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.9.0/playbooks/eumetcast-terrestrial-amt-flavour
       sources:
         - https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning.git
       maintainers:
@@ -1108,12 +1108,12 @@ spec:
         others: "Deployable,EWCCLI-compatible"
       displayName: EUMETCast Terrestrial on AMT Flavour
       summary: Turns a VM into a station that realiably captures and stores data from the EUMETCast Terrestrial service
-      license: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.8.4/LICENSE
+      license: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.9.0/LICENSE
       published: true
 
     eumetsat-s3-mount-flavour:
       name: "eumetsat-s3-mount-flavour"
-      version: "1.8.4"
+      version: "1.9.0"
       ewccli:
         pathToRequirementsFile: playbooks/eumetsat-s3-mount-flavour/requirements.yml
         pathToMainFile: playbooks/eumetsat-s3-mount-flavour/eumetsat-s3-mount-flavour.yml
@@ -1263,7 +1263,7 @@ spec:
         | vfs_cache_mode | Cache mode | `string` | `writes` | yes |
         | vfs_cache_max_size | Max total size of objects in the cache | `string` | `512Mi` | yes |
 
-      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.8.4/playbooks/eumetsat-s3-mount-flavour
+      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.9.0/playbooks/eumetsat-s3-mount-flavour
       sources:
         - https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning.git
       maintainers:
@@ -1279,12 +1279,12 @@ spec:
         others: "Deployable,EWCCLI-compatible"
       displayName: EUMETSAT S3 Mount Flavour
       summary: Enables a VM to access public EUMETSAT data stored in shared S3 buckets, just as if it was on the local filesystem
-      license: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.8.4/LICENSE
+      license: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.9.0/LICENSE
       published: true
 
     eumetsat-data-tailor-flavour:
       name: "eumetsat-data-tailor-flavour"
-      version: "1.8.4"
+      version: "1.9.0"
       ewccli:
         pathToRequirementsFile: playbooks/eumetsat-data-tailor-flavour/requirements.yml
         pathToMainFile: playbooks/eumetsat-data-tailor-flavour/eumetsat-data-tailor-flavour.yml
@@ -1476,7 +1476,7 @@ spec:
         | conda_prefix | prefix where conda will be installed | `string` | `/opt/conda` | yes |
         | conda_user | user that will own the conda installation | `string` | `root` | yes |
 
-      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.8.4/playbooks/eumetsat-data-tailor-flavour
+      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.9.0/playbooks/eumetsat-data-tailor-flavour
       sources:
         - https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning.git
       maintainers:
@@ -1492,7 +1492,7 @@ spec:
         others: "Deployable,EWCCLI-compatible"
       displayName: EUMETSAT Data Tailor Flavour
       summary: Transforms an existing VM into a powerful satellite data customization hub, enabling users to efficiently subset, aggregate, reproject, and reformat data from METOP, MFG, MSG, MTG, and Sentinel-3 into GIS and image formats, offering faster processing and greater flexibility than web-based alternatives.
-      license: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.8.4/LICENSE
+      license: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.9.0/LICENSE
       published: true
 
     ewccli:
@@ -1806,9 +1806,9 @@ spec:
         | os_security_group_name | OpenStack security group containing all firewall rules required for HAProxy operation | `string` | `ssh-http-https` | yes |
 
       displayName: HAProxy
-      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/tree/1.8.4/playbooks/haproxy-flavour
+      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/tree/1.9.0/playbooks/haproxy-flavour
       icon: https://raw.githubusercontent.com/ewcloud/ewc-community-hub/refs/heads/main/logos/EWCLogo.png
-      license: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.8.4/LICENSE
+      license: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.9.0/LICENSE
       maintainers:
         - name: EWC Team
           email: support@europeanweather.cloud
@@ -1828,11 +1828,11 @@ spec:
             default: ssh-http-https
         pathToMainFile: playbooks/haproxy-flavour/haproxy-flavour.yml
         pathToRequirementsFile: playbooks/haproxy-flavour/requirements.yml
-      version: "1.8.4"
+      version: "1.9.0"
 
     default-stack-provisioning:
       name: "default-stack-provisioning"
-      version: "1.8.4"
+      version: "1.9.0"
       description: |
         >✅ This template can be safely applied from any local work environment, even running outside an EWC tenancy's private network.
 
@@ -1847,7 +1847,6 @@ spec:
 
         * Provision the IPA server instance via Terraform, including network validation and automatic subnet DNS updates to enable centralized user management and resource discovery across the environment.
         * Provision the SSH bastion instance via Terraform, configured as a secure entrypoint with intrusion prevention.
-        * Install [python-openstackclient](https://pypi.org/project/python-openstackclient) (version 8.0 or higher)
         * Enroll the newly provisioned SSH bastion as an IPA client, connecting it to the IPA server for centralized credentials and DNS resolution.
         * Provision the remote desktop instance via Terraform, equipped for graphical access over varying bandwidths.
         * Enroll the newly provisioned remote desktop as an IPA client, integrating it with the IPA server for unified access control.
@@ -1868,7 +1867,8 @@ spec:
         ## Prerequisites
 
         * Install [git](https://git-scm.com/downloads) (version 2.0 or higher )
-        * Install [python](https://www.python.org/downloads) (version 3.9 or higher)
+        * Install [python](https://www.python.org/downloads) (version 3.9 or higher) 
+        * Install [python-openstackclient](https://pypi.org/project/python-openstackclient) (version 8.0 or higher)
         * Install [ansible](https://pypi.org/project/ansible) (version 2.15 or higher)
         * Install [terraform](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+-+IaC+via+Terraform+and+OpenTofu#EWCIaCviaTerraformandOpenTofu-InstallationoftheCLI) (version 1.0 or higher)
         * Get OpenStack API credentials (see [How to request OpenStack Application Credentials](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+-+How+to+request+Openstack+Application+Credentials) section of the EWC documentation)
@@ -1879,7 +1879,7 @@ spec:
         > ⚠️ Only RockyLinux versions 9 or 8 are supported due
         to constrains imposed by [dependencies](#dependencies).
 
-        > 💡 VM plans with at least 4GB of RAM is recommended for successful setup and stable operation
+        > 💡 VM plans with at least 4GB of RAM is recommended for successful setup and stable operation 
 
         >⛔ Execution of this template can potentially affect DNS resolution on existing VMs within your subnet. To prevent issues, enroll them to the new IPA server via the
         [IPA Client Enroll Flavour](https://europeanweather.cloud/community-hub/ipa-client-enroll-flavour)
@@ -1951,8 +1951,8 @@ spec:
                 "ipa_server_instance_name":"server",
                 "ipa_server_instance_index": 1,
                 "ipa_server_hostname":"ipa-server-1",
-                "ipa_server_flavor_name":"eo1.large",
-                "ipa_server_image_name":"Rocky-8.10-20250604144456",
+                "ipa_server_flavor_name":"4cpu-8gbmem",
+                "ipa_server_image_name":"Rocky-9.7-20260519081947",
                 "ipa_domain":"eumetsat.sandbox.ewc",
                 "ipa_admin_username":"ipaadmin",
                 "ipa_admin_password":"my-secret-password",
@@ -1962,14 +1962,14 @@ spec:
                 "ssh_bastion_app_name":"ssh",
                 "ssh_bastion_instance_name":"bastion",
                 "ssh_bastion_instance_index": 1,
-                "ssh_bastion_flavor_name":"eo1.large",
-                "ssh_bastion_image_name":"Rocky-9.5-20250604142417",
+                "ssh_bastion_flavor_name":"4cpu-8gbmem",
+                "ssh_bastion_image_name":"Rocky-9.7-20260519081947",
                 "remote_desktop_tf_project_path":"~/ewc/remote-desktop-1",
                 "remote_desktop_app_name":"remote",
                 "remote_desktop_instance_name":"desktop",
                 "remote_desktop_instance_index": 1,
-                "remote_desktop_flavor_name":"eo1.large",
-                "remote_desktop_image_name":"Rocky-9.5-20250604142417",
+                "remote_desktop_flavor_name":"4cpu-8gbmem",
+                "remote_desktop_image_name":"Rocky-9.7-20260519081947",
                 "remote_desktop_instance_has_fip":"yes"
             }' \
             default-stack-provisioning.yml
@@ -1989,8 +1989,8 @@ spec:
         | ipa_server_instance_name| name of the instance, used in the full instance name  | `string` | `server` | yes |
         | ipa_server_instance_index | index or identifier for the instance, used as suffix in the full instance name | `number` | `1` | yes |
         | ipa_server_hostname | hostname of the IPA server. Should match the pattern "<ipa_server_app_name>-<ipa_server_instance_name>-<ipa_server_instance_index>". Required for input validation purpose | `string` | `ipa-server-1` | yes |
-        | ipa_server_flavor_name | name the flavor to use for the instance. To learn about available options, checkout the [official EWC VM plans documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+VM+plans) | `string` | `eo1.large` | yes |
-        | ipa_server_image_name | name of the image to use for the instance. For complete information on  available options, see the [official EWC Images documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+Virtual+Images+Available) | `string` | `Rocky-8.10-20250604144456` | yes |
+        | ipa_server_flavor_name | name the flavor to use for the instance. To learn about available options, checkout the [official EWC VM plans documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+VM+plans) | `string` | `4cpu-8gbmem` | yes |
+        | ipa_server_image_name | name of the image to use for the instance. For complete information on  available options, see the [official EWC Images documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+Virtual+Images+Available) | `string` | `Rocky-8.10-20260519112324` | yes |
         | ipa_domain | domain name to be managed by the IPA server. Example: `eumetsat.sandbox.ewc` | `string` | n/a | yes |
         | ipa_admin_username | username of administrator account to replace the default IPA admin | `string` | `ipaadmin` | yes |
         | ipa_admin_password | password of administrator account to replace the default IPA admin | `string` | n/a | yes |
@@ -2000,18 +2000,18 @@ spec:
         | ssh_bastion_app_name | application name, used as prefix in the full instance name  | `string` | `ssh` | yes |
         | ssh_bastion_instance_name| name of the instance, used in the full instance name  | `string` | `bastion` | yes |
         | ssh_bastion_instance_index | index or identifier for the instance, used as suffix in the full instance name | `number` | `1`  | yes |
-        | ssh_bastion_flavor_name | name the flavor to use for the instance. To learn about available options, checkout the [official EWC VM plans documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+VM+plans) | `string` | `eo1.large` | yes |
-        | ssh_bastion_image_name | name of the image to use for the instance. For complete information on  available options, see the [official EWC Images documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+Virtual+Images+Available) | `string` | `Rocky-9.5-20250604142417` | yes |
+        | ssh_bastion_flavor_name | name the flavor to use for the instance. To learn about available options, checkout the [official EWC VM plans documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+VM+plans) | `string` | `4cpu-8gbmem` | yes |
+        | ssh_bastion_image_name | name of the image to use for the instance. For complete information on  available options, see the [official EWC Images documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+Virtual+Images+Available) | `string` | `Rocky-9.7-20260519081947` | yes |
         | remote_desktop_tf_project_path | path to terraform working directory | `string` | `~/ewc/remote-desktop-1` | yes |
         | remote_desktop_app_name | application name, used as prefix in the full instance name | `string` | `remote`  | yes |
         | remote_desktop_instance_name| name of the instance, used in the full instance name | `string` | `desktop` | yes |
         | remote_desktop_instance_index | index or identifier for the instance, used as suffix in the full instance name | `number` | `1` | yes |
-        | remote_desktop_flavor_name | name the flavor to use for the instance. To learn about available options, checkout the [official EWC VM plans documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+VM+plans)  | `string` | `eo1.large` | yes |
-        | remote_desktop_image_name | name of the image to use for the instance. For complete information on  available options, see the [official EWC Images documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+Virtual+Images+Available) | `string` | `Rocky-9.5-20250604142417`  | yes |
+        | remote_desktop_flavor_name | name the flavor to use for the instance. To learn about available options, checkout the [official EWC VM plans documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+VM+plans)  | `string` | `4cpu-8gbmem` | yes |
+        | remote_desktop_image_name | name of the image to use for the instance. For complete information on  available options, see the [official EWC Images documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+Virtual+Images+Available) | `string` | `Rocky-9.7-20260519081947`  | yes |
         | remote_desktop_instance_has_fip | technically required to temporarily assign a floating IP to the instance to securely connect from localhost during initial configuration. 💡 The template ensures to remove the floating IP during post-provisioning | `string` | `yes` | yes |
         | fail2ban_whitelisted_ip_ranges | IPv4 ranges (in CIDR format) to be whitelisted in Fail2ban configuration. When in doubt, do not set. Example: `['10.0.0.0/24','192.168.1.0/24']` | `list(string)` | `null` | no |
 
-      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.8.4/playbooks/default-stack-provisioning
+      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.9.0/playbooks/default-stack-provisioning
       sources:
         - https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning.git
       maintainers:
@@ -2027,12 +2027,12 @@ spec:
         licenseType: "MIT License"
       displayName: Default Stack Provisioning
       summary: Automates the creation and state management of three VMs, plus their OS configuration. Each of them serves an specific role (IPA server, SSH bastion or remote desktop). Together, they enable secure access, centralized user management, and a fully graphical development environment within the EWC.
-      license: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.8.4/LICENSE
+      license: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.9.0/LICENSE
       published: true
 
     ipa-client-enroll-flavour:
       name: "ipa-client-enroll-flavour"
-      version: "1.8.4"
+      version: "1.9.0"
       ewccli:
         pathToRequirementsFile: playbooks/ipa-client-enroll-flavour/requirements.yml
         pathToMainFile: playbooks/ipa-client-enroll-flavour/ipa-client-enroll-flavour.yml
@@ -2190,7 +2190,7 @@ spec:
         | ipa_admin_username | username of the administrator account from the IPA server | `string` | `ipaadmin` | yes |
         | ipa_admin_password | password of the administrator account from the IPA server. Example: `my-secret-password` | `string` | n/a | yes |
 
-      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.8.4/playbooks/ipa-client-enroll-flavour
+      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.9.0/playbooks/ipa-client-enroll-flavour
       sources:
         - https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning.git
       maintainers:
@@ -2206,12 +2206,12 @@ spec:
         licenseType: "MIT License"
       displayName: IPA Client Enroll Flavour
       summary: Seamlessly integrates a running VM into a FreeIPA-managed fleet of instances, enabling centralized user authentication, DNS resolution, and secure remote access for simplified and scalable identity management.
-      license: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.8.4/LICENSE
+      license: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.9.0/LICENSE
       published: true
 
     ipa-client-disenroll-flavour:
       name: "ipa-client-disenroll-flavour"
-      version: "1.8.4"
+      version: "1.9.0"
       ewccli:
         pathToMainFile: playbooks/ipa-client-disenroll-flavour/ipa-client-disenroll-flavour.yml
         pathToRequirementsFile: playbooks/ipa-client-disenroll-flavour/requirements.yml
@@ -2361,7 +2361,7 @@ spec:
         | ipa_admin_username | username of the administrator account from the IPA server | `string` | `ipaadmin` | yes |
         | ipa_admin_password | password of the administrator account from the IPA server. Example: `my-secret-password` | `string` | n/a | yes |
 
-      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.8.4/playbooks/ipa-client-disenroll-flavour
+      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.9.0/playbooks/ipa-client-disenroll-flavour
       sources:
         - https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning.git
       maintainers:
@@ -2377,12 +2377,12 @@ spec:
         licenseType: "MIT License"
       displayName: IPA Client Disenroll Flavour
       summary: Simplifies the secure removal of a running VM from a FreeIPA-managed fleet of instances, reducing administrative overhead and enhancing security by eliminating stale credentials and DNS records.
-      license: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.8.4/LICENSE
+      license: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.9.0/LICENSE
       published: true
 
     ipa-client-provisioning:
       name: "ipa-client-provisioning"
-      version: "1.8.4"
+      version: "1.9.0"
       description: |
         >✅ This template can be applied from any local work environment, even running outside an EWC tenancy's private network.
 
@@ -2418,7 +2418,7 @@ spec:
         ## Prerequisites
 
         * Install [git](https://git-scm.com/downloads) (version 2.0 or higher )
-        * Install [python](https://www.python.org/downloads) (version 3.9 or higher)
+        * Install [python](https://www.python.org/downloads) (version 3.9 or higher) 
         * Install [python-openstackclient](https://pypi.org/project/python-openstackclient) (version 8.0 or higher)
         * Install [ansible](https://pypi.org/project/ansible) (version 2.15 or higher)
         * Install [terraform](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+-+IaC+via+Terraform+and+OpenTofu#EWCIaCviaTerraformandOpenTofu-InstallationoftheCLI) (version 1.0 or higher)
@@ -2487,8 +2487,8 @@ spec:
                 "app_name": "ipa",
                 "instance_name": "client",
                 "instance_index": 1,
-                "flavor_name": "eo2.medium",
-                "image_name": "ubuntu-22.04-20250204105649",
+                "flavor_name": "1cpu-4gbmem",
+                "image_name": "Ubuntu-22.04-20260519071848",
                 "public_keypair_name": "my-public-key-name",
                 "private_keypair_path": "~/.ssh/id_rsa",
                 "private_network_name": "private",
@@ -2510,8 +2510,8 @@ spec:
         | app_name | application name, used as prefix in the full instance name | `string` | `ipa` | yes |
         | instance_name| name of the instance, used in the full instance name | `string` |  `client` | yes |
         | instance_index | index or identifier for the instance, used as suffix in the full instance name | `number` | `1` | yes |
-        | flavor_name | name the flavor to use for the instance. To learn about available options, checkout the [official EWC VM plans documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+VM+plans) | `string` | `eo1.large` | yes |
-        | image_name | name of the image to use for the instance. For complete information on  available options, see the [official EWC Images documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+Virtual+Images+Available) | `string` | `ubuntu-22.04-20250204105649` | yes |
+        | flavor_name | name the flavor to use for the instance. To learn about available options, checkout the [official EWC VM plans documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+VM+plans) | `string` | `4cpu-8gbmem` | yes |
+        | image_name | name of the image to use for the instance. For complete information on  available options, see the [official EWC Images documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+Virtual+Images+Available) | `string` | `Ubuntu-22.04-20260519071848` | yes |
         | public_keypair_name | name of public keypair (stored in OpenStack) to be copied into the instance for remote SSH access | `string` | n/a | yes |
         | private_keypair_path | path to the local private keypair to use for SSH access to the instance  | `string` | `~/.ssh/id_rsa` | yes |
         | private_network_name | private network name to attach the instance to  | `string` | `private`| yes |
@@ -2522,7 +2522,7 @@ spec:
         | ipa_admin_username | username of the administrator account from the IPA server | `string` | `ipaadmin` | yes |
         | ipa_admin_password | password of the administrator account from the IPA server | `string` | n/a | yes |
 
-      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.8.4/playbooks/ipa-client-provisioning
+      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.9.0/playbooks/ipa-client-provisioning
       sources:
         - https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning.git
       maintainers:
@@ -2538,12 +2538,12 @@ spec:
         licenseType: "MIT License"
       displayName: IPA Client Provisioning
       summary: Automates the creation or state update of a VM, plus its configuration as an IPA client, effectively enabling integration with a fleet of instances with centralized authentication, secure remote access, and DNS-based resource discovery in the EWC.
-      license: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.8.4/LICENSE
+      license: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.9.0/LICENSE
       published: true
 
     ipa-client-teardown:
       name: "ipa-client-teardown"
-      version: "1.8.4"
+      version: "1.9.0"
       description: |
         >✅ This template can be safely applied from any local work environment, even running outside an EWC tenancy's private network.
 
@@ -2655,7 +2655,7 @@ spec:
         | ipa_admin_username | username of the administrator account from the IPA server | `string` | `ipaadmin` | yes |
         | ipa_admin_password | password of the administrator account from the IPA server | `string` | n/a | yes |
 
-      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.8.4/playbooks/ipa-client-teardown
+      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.9.0/playbooks/ipa-client-teardown
       sources:
         - https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning.git
       maintainers:
@@ -2671,12 +2671,12 @@ spec:
         licenseType: "MIT License"
       displayName: IPA Client Teardown
       summary: Simplifies the secure teardown of an IPA client VM in the EWC, disabling LDAP authentication, removing DNS records, and safely decommissioning the instance and its resources.
-      license: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.8.4/LICENSE
+      license: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.9.0/LICENSE
       published: true
 
     ipa-server-flavour:
       name: "ipa-server-flavour"
-      version: "1.8.4"
+      version: "1.9.0"
       ewccli:
         defaultImageName: Rocky-9.6-20251107141503
         pathToRequirementsFile: playbooks/ipa-server-flavour/requirements.yml
@@ -2932,7 +2932,7 @@ spec:
         | os_network_name | OpenStack network to which the target virtual machine has access to | `string` | `private` | yes |
         | os_security_group_name | OpenStack security group containing all firewall rules required by the IPA server/client communication | `string` | `ipa` | yes |
 
-      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.8.4/playbooks/ipa-server-flavour
+      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.9.0/playbooks/ipa-server-flavour
       sources:
         - https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning.git
       maintainers:
@@ -2948,12 +2948,12 @@ spec:
         licenseType: "MIT License"
       displayName: IPA Server Flavour
       summary: Turns an existing VM into a FreeIPA server, a central place for user authentication, authorization, and DNS-based resource discovery for secure and efficient identity management.
-      license: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.8.4/LICENSE
+      license: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.9.0/LICENSE
       published: true
 
     ipa-server-provisioning:
       name: "ipa-server-provisioning"
-      version: "1.8.4"
+      version: "1.9.0"
       description: |
         >✅ This template can be safely applied from any local work environment, even running outside an EWC tenancy's private network.
 
@@ -2996,7 +2996,7 @@ spec:
         ## Prerequisites
 
         * Install [git](https://git-scm.com/downloads) (version 2.0 or higher )
-        * Install [python](https://www.python.org/downloads) (version 3.9 or higher)
+        * Install [python](https://www.python.org/downloads) (version 3.9 or higher) 
         * Install [python-openstackclient](https://pypi.org/project/python-openstackclient) (version 8.0 or higher)
         * Install [ansible](https://pypi.org/project/ansible) (version 2.15 or higher)
         * Install [terraform](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+-+IaC+via+Terraform+and+OpenTofu#EWCIaCviaTerraformandOpenTofu-InstallationoftheCLI) (version 1.0 or higher)
@@ -3067,8 +3067,8 @@ spec:
                 "ipa_server_app_name":"ipa",
                 "ipa_server_instance_name":"server",
                 "ipa_server_instance_index": 1,
-                "ipa_server_flavor_name":"eo1.large",
-                "ipa_server_image_name":"Rocky-8.10-20250604144456",
+                "ipa_server_flavor_name":"4cpu-8gbmem",
+                "ipa_server_image_name":"Rocky-9.7-20260519081947",
                 "public_keypair_name":"my-public-key-name",
                 "private_keypair_path":"~/.ssh/id_rsa",
                 "private_network_name": "private",
@@ -3114,8 +3114,8 @@ spec:
         | ipa_server_app_name | application name, used as prefix in the full instance name | `string` | `ipa` | yes |
         | ipa_server_instance_name| name of the instance, used in the full instance name | `string` | `server` | yes |
         | ipa_server_instance_index | index or identifier for the instance, used as suffix in the full instance name | `number` | `1` | yes |
-        | ipa_server_flavor_name | name the flavor to use for the instance. To learn about available options, checkout the [official EWC VM plans documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+VM+plans) | `string` | `eo1.large` | yes |
-        | ipa_server_image_name | name of the image to use for the instance. For complete information on  available options, see the [official EWC Images documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+Virtual+Images+Available) | `string` | `Rocky-8.10-20250604144456` | yes |
+        | ipa_server_flavor_name | name the flavor to use for the instance. To learn about available options, checkout the [official EWC VM plans documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+VM+plans) | `string` | `4cpu-8gbmem` | yes |
+        | ipa_server_image_name | name of the image to use for the instance. For complete information on  available options, see the [official EWC Images documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+Virtual+Images+Available) | `string` | `Rocky-8.10-20260519112324` | yes |
         | public_keypair_name | name of public keypair (stored in OpenStack) to be copied into the instance for remote SSH access | `string` | n/a | yes |
         | private_keypair_path | path to the local private keypair to use for SSH access to the instance  | `string` | `~/.ssh/id_rsa` | yes |
         | private_network_name | private network name to attach the instance | `string` | `private`  | yes |
@@ -3126,7 +3126,7 @@ spec:
         | ipa_admin_givenname | given name of the administrator to replace the default IPA admin (needs not be a physical person) | `string` | `EWC` | yes |
         | ipa_admin_surname | surname of the administrator to replace the default IPA admin (needs not to belong to a physical person)  | `string` | `IPAADMIN` | yes |
 
-      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.8.4/playbooks/ipa-server-provisioning
+      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.9.0/playbooks/ipa-server-provisioning
       sources:
         - https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning.git
       maintainers:
@@ -3142,7 +3142,7 @@ spec:
         licenseType: "MIT License"
       displayName: IPA Server Provisioning
       summary: Automates the creation or state update of VM, plus its configuration as FreeIPA server, streamlining centralized user management, authentication, authorization, and DNS resolution for secure and efficient resource management.
-      license: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.8.4/LICENSE
+      license: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.9.0/LICENSE
       published: true
 
     jupyterhub-flavour:
@@ -3451,9 +3451,9 @@ spec:
          | os_security_group_name | OpenStack security group containing all firewall rules required for Nginx Proxy Manager operation  | `string` | `nginx-proxy-manager` | yes |
 
       displayName: Nginx Proxy Manager
-      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/tree/1.8.4/playbooks/nginx-proxy-manager-flavour
+      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/tree/1.9.0/playbooks/nginx-proxy-manager-flavour
       icon: https://raw.githubusercontent.com/ewcloud/ewc-community-hub/refs/heads/main/logos/EWCLogo.png
-      license: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.8.4/LICENSE
+      license: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.9.0/LICENSE
       maintainers:
         - name: EWC Team
           email: support@europeanweather.cloud
@@ -3477,7 +3477,7 @@ spec:
         ansibleUser: ubuntu
         pathToMainFile: playbooks/nginx-proxy-manager-flavour/nginx-proxy-manager-flavour.yml
         pathToRequirementsFile: playbooks/nginx-proxy-manager-flavour/requirements.yml
-      version: "1.8.4"
+      version: "1.9.0"
 
     nwcsaf-datacube-xarray:
       name: "nwcsaf-datacube-xarray"
@@ -4095,7 +4095,7 @@ spec:
 
     remote-desktop-flavour:
       name: "remote-desktop-flavour"
-      version: "1.8.4"
+      version: "1.9.0"
       ewccli:
         defaultImageName: Rocky-9.6-20251107141503
         pathToRequirementsFile: playbooks/remote-desktop-flavour/requirements.yml
@@ -4263,7 +4263,7 @@ spec:
         |------|-------------|------|---------|----------|
         | fail2ban_whitelisted_ip_ranges | IPv4 ranges (in CIDR format) to be whitelisted in Fail2ban configuration. When in doubt, do not set. Example: `['10.0.0.0/24','192.168.1.0/24']` | `list(string)` | `null` | no |
 
-      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.8.4/playbooks/remote-desktop-flavour
+      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.9.0/playbooks/remote-desktop-flavour
       sources:
         - https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning.git
       maintainers:
@@ -4279,12 +4279,12 @@ spec:
         licenseType: "MIT License"
       displayName: Remote Desktop Flavour
       summary: Transforms an existing VM into a secure, graphical desktop environment using X2Go and MATE, enabling simple remote access and intuitive cloud-based development for tenant users.
-      license: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.8.4/LICENSE
+      license: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.9.0/LICENSE
       published: true
 
     remote-desktop-provisioning:
       name: "remote-desktop-provisioning"
-      version: "1.8.4"
+      version: "1.9.0"
       description: |
         >✅ This template can be safely applied from any local work environment, even running outside an EWC tenancy's private network.
 
@@ -4327,7 +4327,7 @@ spec:
         ## Prerequisites
 
         * Install [git](https://git-scm.com/downloads) (version 2.0 or higher )
-        * Install [python](https://www.python.org/downloads) (version 3.9 or higher)
+        * Install [python](https://www.python.org/downloads) (version 3.9 or higher) 
         * Install [python-openstackclient](https://pypi.org/project/python-openstackclient) (version 8.0 or higher)
         * Install [ansible](https://pypi.org/project/ansible) (version 2.15 or higher)
         * Install [terraform](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+-+IaC+via+Terraform+and+OpenTofu#EWCIaCviaTerraformandOpenTofu-InstallationoftheCLI) (version 1.0 or higher)
@@ -4398,8 +4398,8 @@ spec:
                 "remote_desktop_app_name":"remote",
                 "remote_desktop_instance_name":"desktop",
                 "remote_desktop_instance_index":1,
-                "remote_desktop_flavor_name":"eo1.large",
-                "remote_desktop_image_name":"Rocky-9.5-20250604142417",
+                "remote_desktop_flavor_name":"4cpu-8gbmem",
+                "remote_desktop_image_name":"Rocky-9.7-20260519081947",
                 "remote_desktop_instance_has_fip":"no",
                 "public_keypair_name":"my-public-key-name",
                 "private_keypair_path":"~/.ssh/id_rsa",
@@ -4434,8 +4434,8 @@ spec:
         | remote_desktop_app_name | application name, used as prefix in the full instance name | `string` | `remote` | yes |
         | remote_desktop_instance_name| name of the instance, used in the full instance name | `string` | `desktop` | yes |
         | remote_desktop_instance_index | index or identifier for the instance, used as suffix in the full instance name | `number` | `1` | yes |
-        | remote_desktop_flavor_name | name the flavor to use for the instance. To learn about available options, checkout the [official EWC VM plans documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+VM+plans) | `string` | `eo1.large` | yes |
-        | remote_desktop_image_name | name of the image to use for the instance. For complete information on  available options, see the [official EWC Images documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+Virtual+Images+Available) | `string` | `Rocky-9.5-20250604142417` | yes |
+        | remote_desktop_flavor_name | name the flavor to use for the instance. To learn about available options, checkout the [official EWC VM plans documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+VM+plans) | `string` | `4cpu-8gbmem` | yes |
+        | remote_desktop_image_name | name of the image to use for the instance. For complete information on  available options, see the [official EWC Images documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+Virtual+Images+Available) | `string` | `Rocky-9.7-20260519081947` | yes |
         | remote_desktop_instance_has_fip | whether to assign a floating IP to the instance. Only `yes` will be accepted to approve | `string` | `no` | no |
         | public_keypair_name | name of public keypair (stored in OpenStack) to be copied into the instance for remote SSH access | `string` | n/a | yes |
         | private_keypair_path| path to the local private keypair to use for SSH access to the instance | `string` | `~/.ssh/id_rsa` | yes |
@@ -4443,7 +4443,7 @@ spec:
         | security_group_name | security group name to apply to the instance | `string` | `ipa` | yes |
         | fail2ban_whitelisted_ip_ranges | IPv4 ranges (in CIDR format) to be whitelisted in Fail2ban configuration. When in doubt, do not set. Example: `['10.0.0.0/24','192.168.1.0/24']` | `list(string)` | `null` | no |
 
-      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.8.4/playbooks/remote-desktop-provisioning
+      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.9.0/playbooks/remote-desktop-provisioning
       sources:
         - https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning.git
       maintainers:
@@ -4459,12 +4459,12 @@ spec:
         licenseType: "MIT License"
       displayName: Remote Desktop Provisioning
       summary: Automates the creation or state update of a remote desktop VM, a basic yet secure cloud-based development environment with graphical interface. Uses X2Go and MATE to enable easy remote access for tenant users.
-      license: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.8.4/LICENSE
+      license: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.9.0/LICENSE
       published: true
 
     ssh-bastion-flavour:
       name: "ssh-bastion-flavour"
-      version: "1.8.4"
+      version: "1.9.0"
       ewccli:
         defaultImageName: Rocky-9.6-20251107141503
         pathToRequirementsFile: playbooks/ssh-bastion-flavour/requirements.yml
@@ -4615,7 +4615,7 @@ spec:
         |------|-------------|------|---------|----------|
         | fail2ban_whitelisted_ip_ranges | IPv4 ranges (in CIDR format) to be whitelisted in Fail2ban configuration. When in doubt, do not set. Example: `['10.0.0.0/24','192.168.1.0/24']` | `list(string)` | `null` | no |
 
-      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/tree/1.8.4/playbooks/ssh-bastion-flavour
+      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/tree/1.9.0/playbooks/ssh-bastion-flavour
       sources:
         - https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning.git
       maintainers:
@@ -4631,21 +4631,21 @@ spec:
         licenseType: "MIT License"
       displayName: SSH Bastion Flavour
       summary: Tightens the configuration of a running VM, to operate as a secure SSH proxy with Fail2ban, providing tenant admins and users a fortified entry point to safely access private EWC networks from the public internet.
-      license: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.8.4/LICENSE
+      license: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.9.0/LICENSE
       published: true
 
     ssh-bastion-provisioning:
       name: "ssh-bastion-provisioning"
-      version: "1.8.4"
+      version: "1.9.0"
       description: |
         >✅ This template can be safely applied from any local work environment, even running outside an EWC tenancy's private network.
 
-        The [SSH](https://en.wikipedia.org/wiki/Secure_Shell) proxy or bastion server
-        is a barrier between your internal machines (without public or floating IPs)
-        and the public internet. With the SSH proxy, you'll have an extra layer of
-        security on top of your instances. It's equipped with
-        [Fail2ban](https://github.com/fail2ban/fail2ban),
-        intrusion prevention software designed to prevent brute-force attacks.
+        The remote desktop is a regular RockyLinux instance equipped with [X2Go](https://wiki.x2go.org/doku.php).
+        It enables you to access a graphical desktop computer running in your remote
+        instance of choice, over a low bandwidth (or high bandwidth) connection.
+        This means that you can connect to it via the
+        [X2Go client](https://wiki.x2go.org/doku.php/doc:installation:x2goclient)
+        to enjoy a regular desktop user experience.
 
         This is a configuration template
         (i.e. an [Ansible Playbook](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks.html))
@@ -4663,19 +4663,23 @@ spec:
           instance from scratch
 
             OR
-          * If  `terraform.tfstate` file is found, leverages Terraform's out-of-the-box functionality to update the instance referenced on it
-        * Configure the existing or newly provisioned RockyLinux virtual machines (with
-        public IP address), as entrypoint for users who wish to reach private EWC networks
-        from the public internet via SSH.
+          * If  `terraform.tfstate` file is found, leverages Terraform's out-of-the-box
+            functionality to update the instance referenced on it
+        * Configure the existing or newly provisioned instance such that it:
+          * Enables users to operate the remote hosts through a graphical desktop
+            (i.e. a [MATE desktop environment](https://mate-desktop.org/)), over a low or high bandwidth connection.
 
         After successful provisioning, you can leverage Terraform's functionality to modify or delete individual components safely. Each will have its own `main.tf` definition and `terraform.tfstate` state file under the corresponding user-defined local directories.
 
         To learn the basics about managing infrastructure with Terraform, check out [Terraform in 100 seconds](https://youtu.be/tomUWcQ0P3k?si=CJwZJ7UaqpynDU-d) on YouTube. You can also find a step-by-step example applied to the EWC on the [official EWC documentation](https://confluence.ecmwf.int/x/2EDOIQ).
 
+
+        >💡 This template can be deployed in combination with complementary infrastructure as part of the [Default Stack Provisioning](https://europeanweather.cloud/community-hub/default-stack-provisioning) Community Hub Item.
+
         ## Prerequisites
 
         * Install [git](https://git-scm.com/downloads) (version 2.0 or higher )
-        * Install [python](https://www.python.org/downloads) (version 3.9 or higher)
+        * Install [python](https://www.python.org/downloads) (version 3.9 or higher) 
         * Install [python-openstackclient](https://pypi.org/project/python-openstackclient) (version 8.0 or higher)
         * Install [ansible](https://pypi.org/project/ansible) (version 2.15 or higher)
         * Install [terraform](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+-+IaC+via+Terraform+and+OpenTofu#EWCIaCviaTerraformandOpenTofu-InstallationoftheCLI) (version 1.0 or higher)
@@ -4698,7 +4702,7 @@ spec:
         #### 1.1. Change to the specific Item's subdirectory
 
         ```bash
-        cd ewc-ansible-playbook-flavours-and-provisioning/playbooks/ssh-bastion-provisioning
+        cd ewc-ansible-playbook-flavours-and-provisioning/playbooks/remote-desktop-provisioning
         ```
 
         #### 1.2. (Optional) Checkout an specific Item's version
@@ -4726,7 +4730,7 @@ spec:
         target EWC environment:
 
         ```bash
-        ansible-playbook ssh-bastion-provisioning.yml
+        ansible-playbook remote-desktop-provisioning.yml
         ```
 
         #### 3.2. Non-Interactive Mode
@@ -4742,37 +4746,56 @@ spec:
         ansible-playbook \
           -e '{
                 "ewc_provider":"eumetsat",
-                "ssh_bastion_tf_project_path":"~/ewc/ssh-bastion-1",
-                "ssh_bastion_app_name":"ssh",
-                "ssh_bastion_instance_name":"bastion",
-                "ssh_bastion_instance_index":1,
-                "ssh_bastion_flavor_name":"eo1.large",
-                "ssh_bastion_image_name":"Rocky-9.5-20250604142417",
+                "remote_desktop_tf_project_path":"~/ewc/remote-desktop-1",
+                "remote_desktop_app_name":"remote",
+                "remote_desktop_instance_name":"desktop",
+                "remote_desktop_instance_index":1,
+                "remote_desktop_flavor_name":"4cpu-8gbmem",
+                "remote_desktop_image_name":"Rocky-9.7-20260519081947",
+                "remote_desktop_instance_has_fip":"no",
                 "public_keypair_name":"my-public-key-name",
                 "private_keypair_path":"~/.ssh/id_rsa",
                 "private_network_name":"private",
                 "security_group_name":"ssh"
             }' \
-          ssh-bastion-provisioning.yml
+          remote-desktop-provisioning.yml
         ```
+
+        ### 4. Install the local client and connect to your remote desktop
+        >⚠️ When configuring a connection, be sure to select "MATE" (instead of
+        "KDE" or any other options) in the `Session Type` drop-down list, towards the
+        bottom of the `Session` tab. This is required for the local client to correctly
+        communicate with your remote desktop.
+
+        Install the remote desktop client on Microsoft Window, Mac OS or Linux by
+        following the links on the [official X2Go installation page](https://wiki.x2go.org/doku.php/doc:installation:x2goclient). Then follow the [official X2Go client usage page](https://wiki.x2go.org/doku.php/doc:usage:x2goclient)
+        if you do not know how to configure a new session.
+
+        For a session creation
+        example, representative of a typical EWC environment, checkout the Remote
+        Desktop section of
+        [this official EWC documentation page](https://confluence.ecmwf.int/display/EWCLOUDKB/EUMETSAT+tenancy%3A+Default+setup).
+
+
         ## Inputs
 
         | Name | Description | Type | Default | Required |
         |------|-------------|------|---------|----------|
         | ewc_provider | your target EWC provider. Must match that the provider of your OpenStack application credentials. Valid input values are `ecmwf` or `eumetsat`. | `string` | `eumetsat` | yes |
-        | ssh_bastion_tf_project_path | path to terraform working directory | `string` | `~/ewc/ssh-bastion-1` | yes |
-        | ssh_bastion_app_name | application name, used as prefix in the full instance name  | `string` | `ssh` | yes |
-        | ssh_bastion_instance_name| name of the instance, used in the full instance name | `string` | `bastion` | yes |
-        | ssh_bastion_instance_index | index or identifier for the instance, used as suffix in the full instance name | `number` | `1` | yes |
-        | ssh_bastion_flavor_name | name the flavor to use for the instance. To learn about available options, checkout the [official EWC VM plans documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+VM+plans) | `string` | `eo1.large` | yes |
-        | ssh_bastion_image_name | name of the image to use for the instance. For complete information on  available options, see the [official EWC Images documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+Virtual+Images+Available)  | `string` | `Rocky-9.5-20250604142417` | yes |
+        | remote_desktop_tf_project_path | path to terraform working directory | `string` | `~/ewc/remote-desktop-1` | yes |
+        | remote_desktop_app_name | application name, used as prefix in the full instance name | `string` | `remote` | yes |
+        | remote_desktop_instance_name| name of the instance, used in the full instance name | `string` | `desktop` | yes |
+        | remote_desktop_instance_index | index or identifier for the instance, used as suffix in the full instance name | `number` | `1` | yes |
+        | remote_desktop_flavor_name | name the flavor to use for the instance. To learn about available options, checkout the [official EWC VM plans documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+VM+plans) | `string` | `4cpu-8gbmem` | yes |
+        | remote_desktop_image_name | name of the image to use for the instance. For complete information on  available options, see the [official EWC Images documentation](https://confluence.ecmwf.int/display/EWCLOUDKB/EWC+Virtual+Images+Available) | `string` | `Rocky-9.7-20260519081947` | yes |
+        | remote_desktop_instance_has_fip | whether to assign a floating IP to the instance. Only `yes` will be accepted to approve | `string` | `no` | no |
         | public_keypair_name | name of public keypair (stored in OpenStack) to be copied into the instance for remote SSH access | `string` | n/a | yes |
-        | private_keypair_name | path to the local private keypair to use for SSH access to the instance  | `string` | `~/.ssh/id_rsa` | yes |
-        | private_network_name | private network name to attach the instance to  | `string` | `private` | yes |
-        | security_group_name | security group name to apply to the instance | `string` | `ssh` | yes |
-        | fail2ban_whitelisted_ip_ranges | IPv4 ranges (in CIDR format) to be whitelisted in Fail2ban configuration. Example: `['10.0.0.0/24','192.168.1.0/24']` | `list(string)` | `null` | no |
+        | private_keypair_path| path to the local private keypair to use for SSH access to the instance | `string` | `~/.ssh/id_rsa` | yes |
+        | private_networks_name | private network name to attach the instance to  | `string` | `private` | yes |
+        | security_group_name | security group name to apply to the instance | `string` | `ipa` | yes |
+        | fail2ban_whitelisted_ip_ranges | IPv4 ranges (in CIDR format) to be whitelisted in Fail2ban configuration. When in doubt, do not set. Example: `['10.0.0.0/24','192.168.1.0/24']` | `list(string)` | `null` | no |
 
-      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.8.4/playbooks/ssh-bastion-provisioning
+      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.9.0/playbooks/ssh-bastion-provisioning
       sources:
         - https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning.git
       maintainers:
@@ -4788,12 +4811,12 @@ spec:
         licenseType: "MIT License"
       displayName: SSH Bastion Provisioning
       summary: Automates the creation or state update of a secure SSH bastion VM in the EWC, configured with Fail2ban to provide a fortified entry point for safely accessing private EWC networks from the public internet.
-      license: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.8.4/LICENSE
+      license: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.9.0/LICENSE
       published: true
 
     xcube-viewer-flavour:
       name: "xcube-viewer-flavour"
-      version: "1.8.4"
+      version: "1.9.0"
       ewccli:
         defaultImageName: ubuntu-24.04-2025060410260
         defaultSecurityGroups: [ssh-http-https]
@@ -5018,7 +5041,7 @@ spec:
         | numcodecs | https://anaconda.org/channels/conda-forge/packages/numcodecs/overview |
         | xcube | https://anaconda.org/channels/conda-forge/packages/xcube/files |
 
-      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.8.4/playbooks/xcube-viewer-flavour
+      home: https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/blob/1.9.0/playbooks/xcube-viewer-flavour
       sources:
         - https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning.git
       maintainers:


### PR DESCRIPTION
Hello @pacospace,

Much as https://github.com/ewcloud/ewc-self-service-kubernetes/pull/13, this PRs aims at enabling deployment of the EUMETSAT "provisioning" Items into the new EUMETSAT cloud. 

Changes were manually tested on `coreservices-val` for a subset of the Items (i.e. `ssh-bastion-provisioning` and `remote-desktop-provisioning`), then rollout out to the other relevant Items.

For details about what exactly changed, checkout https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/pull/41 .