### PR TITLE
Index latest  EWCCLI version inc. relevant user-facing docs

### DIFF
--- a/items.yaml
+++ b/items.yaml
@@ -1497,10 +1497,9 @@ spec:
 
     ewccli:
       name: "ewccli"
-      version: "0.1.0"
+      version: "0.6.0"
       description: |
-        ewccli Python Package is the European Weather Cloud (EWC) Command Line Interface (CLI).
-        This tool is developed to support EWC users on the use of the EWC services.
+        The `ewccli` is the European Weather Cloud (EWC) Command Line Interface (CLI). This tool is developed to support EWC users on the use of the EWC services.
 
         ## Prerequisites
 
@@ -1524,11 +1523,143 @@ spec:
         pip install ewccli
         ```
 
+        ### Installing from source
+
+        1. Clone this repository and move into it
+        ```bash
+        git clone THIS_REPO && cd ewccli
+        ```
+
+        2. Create a virtual environment with python version >= 3.10
+
+        ```bash
+        python3 -m venv ewcclienv
+        ```
+
+        3. Activate the virtual environment
+
+        ```bash
+        source ./ewcclienv/bin/activate
+        ```
+
+        4. Upgrade pip
+
+        ```bash
+        pip install --upgrade pip
+        ```
+
+        5. Install the package
+
+        ```bash
+        pip install -e .
+        ```
+
+        ### Installing in a container
+        > If [Docker](https://www.docker.com/) is your preferred containerization tool, you can replace `podman` with `docker` in the commands below.
+
+        You may also run in an completely isolated environment using containerization. After cloning the repository and `cd` into it.
+
+        1. Clone this repository and move into it
+        ```bash
+        git clone THIS_REPO && cd ewccli
+        ```
+
+        2. Create a wheel package (`./dist/ewccli-<version>-py3-none-any.whl`)
+
+        ```bash
+        pip install -q build
+        ```
+
+        ```bash
+        python3 -m build
+        ```
+
+        3. Build an image including the package previously created
+
+        ```bash
+        podman build --no-cache -t ewccli -f ./Containerfile .
+        ```
+
+        4. Start a container with an interactive shell
+
+        ```bash
+        podman run -it --rm  --workdir /home/ewccli --entrypoint /bin/bash ewccli
+        ```
+
         ## Getting started
 
-        Once installed, run `ewc` to verify everything works.
+        Then run `ewc` to verify everything works:
 
-      home: https://github.com/ewcloud/ewccli/tree/0.1.0
+        ![ewccli-default](https://raw.githubusercontent.com/ewcloud/ewccli/main/images/ewccli-default.png)
+
+        If you get a WARNING like `WARNING: The script ewc is installed in '~/.local/bin' which is not on PATH.` Add the following to your profile configuration file:
+
+        ```bash
+        echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.profile
+        ```
+
+        ## Login to prepare the environment
+
+        ```bash
+        ewc login
+        ```
+
+        IMPORTANT:
+
+        - EWC CLI uses the following order of importance:
+            - env variables
+            - cli config
+            - any other config (e.g. Openstack cloud.yaml or Kubernetes `kubeconfig` file)
+
+        All your profiles are saved under `~/.ewccli/profiles`
+
+        You can manually add profiles in the same file and the ewccli can use them already.
+
+        Info required for a profile:
+        ```
+        [my-profile]
+        federee = EUMETSAT or ECMWF
+        tenant_name = eumetsat-ewc-communityhub
+        application_credential_id =
+        application_credential_secret =
+        ssh_public_key_path =
+        ssh_private_key_path =
+        ```
+
+        ## List Items in the catalog
+
+        The following command shows the current available Items. Official Items are listed [here](https://github.com/ewcloud/ewc-community-hub/blob/main/items.yaml).
+
+        ```bash
+        ewc hub list
+        ```
+        ![ewccli-hub-list](https://raw.githubusercontent.com/ewcloud/ewccli/main/images/ewccli-hub-list.png)
+
+
+        ## Deploy Items from the catalog
+
+        ![ewccli-hub-deploy](https://raw.githubusercontent.com/ewcloud/ewccli/main/images/ewccli-hub-deploy.png)
+
+        ```bash
+        ewc hub deploy ITEM
+        ```
+        where ITEM is taken from `ewc hub list` command under Item column.
+
+        ## Test Items unreleased or from private sources
+
+        If you would like to test the deployment of:
+        * **an Item with private source code (local or remote)**
+
+          OR
+        * **a new Item, not yet published in the EWC Community Hub**
+
+          OR
+
+        * **a new version of an Item, not yet updated in the EWC Community Hub**
+
+        you can take advantage of the `--path-to-catalog` to point the EWCCLI to the correct source location, and deploy the Item to your target tenant of choice.
+
+      home: https://github.com/ewcloud/ewccli/tree/0.6.0
       sources:
         - https://github.com/ewcloud/ewccli.git
       maintainers:
@@ -1542,7 +1673,7 @@ spec:
         licenseType: "GNU General Public License v3.0"
       displayName: EWC CLI
       summary: European Weather Cloud (EWC) Command Line Interface (CLI) to interact with EWC services.
-      license: https://github.com/ewcloud/ewccli/blob/0.1.0/LICENSE
+      license: https://github.com/ewcloud/ewccli/blob/0.6.0/LICENSE
       published: true
 
     ewc-gh-action-test-deploy-ansible-playbook:


### PR DESCRIPTION
Hey @pacospace ,

This PR updates relevant metadata of the EWCCLI, which had not changed since it was first indexed in the catalog. 

**Why is this important**

This is recommended, as an attempt to guide users towards a newer version of the tool, which no longer includes a short-list of hard-coded OS images (e.g. https://github.com/ewcloud/ewccli/pull/41)  onto which deployment is allowed. We want to help users avoid this design failure of previous EWCCLI version, which tied the release cycle of OS images to that of the EWCCLI and demanded them to update their EWCCLI installation to be able to deploy anything.


In addition to this PR, consider:
* Broadcasting via suitable communication channels that users ought to update the EWCCLI version if they haven't done so, highlighting that older versions are not functional anymore
* As last resort, delete older releases of the EWCCLI from pypi -> this should be possible via the UI. 

  Note that this is unconventional and generally advised against as it may affect other Python packages that use EWCCLI as dependency currently... though I'd say is a justifiable decision at this point in time.