### PR TITLE
Bump version of the OpenStack Compute TF module Item

### DIFF
--- a/items.yaml
+++ b/items.yaml
@@ -297,7 +297,7 @@ spec:
 
         Before proceeding, if you lack OpenStack Application Credentials or do not know
         how to make them available to Ansible in your development environment, make sure
-        to check out the 
+        to check out the
         [EWC documentation](https://confluence.ecmwf.int/x/TiRNH).
 
         ## Usage
@@ -312,26 +312,26 @@ spec:
           image_id       = "your-image-id"
           flavor_id      = "your-flavor-id"
           keypair_name   = "your-keypair-name"
-          
+
           networks = ["internal"]
-          
+
           instance_has_fip = true
-          
+
           os_volume = {
             enable = true
             size   = 80
           }
-          
+
           extra_volume      = true
           extra_volume_size = 100
-          
+
           security_groups = ["default", "web"]
-          
+
           instance_metadata = {
             environment = "production"
             role        = "web"
           }
-          
+
           tags = {
             environment = "production"
             project     = "website"

--- a/items.yaml
+++ b/items.yaml
@@ -276,7 +276,7 @@ spec:
 
     ewc-tf-module-openstack-compute:
       name: "ewc-tf-module-openstack-compute"
-      version: "1.4.0"
+      version: "1.5.0"
       description: |
         This [Terraform module](https://developer.hashicorp.com/terraform/language/modules) creates and
         configures [OpenStack compute](https://docs.openstack.org/nova/latest/)
@@ -293,6 +293,13 @@ spec:
         - Flexible networking options
         - Resource tagging support with automatic app_name tagging
 
+        ## Authentication
+
+        Before proceeding, if you lack OpenStack Application Credentials or do not know
+        how to make them available to Ansible in your development environment, make sure
+        to check out the 
+        [EWC documentation](https://confluence.ecmwf.int/x/TiRNH).
+
         ## Usage
 
         ```hcl
@@ -305,26 +312,26 @@ spec:
           image_id       = "your-image-id"
           flavor_id      = "your-flavor-id"
           keypair_name   = "your-keypair-name"
-
+          
           networks = ["internal"]
-
+          
           instance_has_fip = true
-
+          
           os_volume = {
             enable = true
             size   = 80
           }
-
+          
           extra_volume      = true
           extra_volume_size = 100
-
+          
           security_groups = ["default", "web"]
-
+          
           instance_metadata = {
             environment = "production"
             role        = "web"
           }
-
+          
           tags = {
             environment = "production"
             project     = "website"
@@ -359,55 +366,7 @@ spec:
         | external_network_name | Name of the external network for floating IPs | `string` | `"external"` | no |
         | tags | A map of tags to assign to all resources that support it | `map(string)` | `{}` | no |
 
-        ## SW Bill of Materials (SBoM)
-        Third-party components used in the working environment.
-
-        The following components will be included in the working environment:
-        | Component | Version | License | Home URL |
-        |------|---------|---------|--------------|
-        | terraform-provider-openstack | 1.53.0 |  MPL-2.0 |  https://github.com/terraform-provider-openstack/terraform-provider-openstack   |
-
-        ## Outputs
-
-        | Name | Description |
-        |------|-------------|
-        | instance-data | Comprehensive information about the created instance |
-        | volumes | Information about the attached volumes |
-
-        ## Instance Output Structure
-
-        ```hcl
-        {
-          name           = "app-name-instance-name-01"
-          id             = "instance-id"
-          internal_ip    = "192.168.1.10"
-          floating_ip    = "203.0.113.10"
-          networks       = [/* Network details */]
-          flavor_id      = "flavor-id"
-          volumes        = ["volume-id-1", "volume-id-2"]
-          access_address = "203.0.113.10"  # or internal IP if no floating IP
-        }
-        ```
-
-        ## Volumes Output Structure
-
-        ```hcl
-        {
-          primary  = "volume-id-primary"  # if os_volume.enable = true
-          volume_1 = {
-            id   = "volume-id-1"
-            name = "app_name_instance_name_01_volume"
-            size = 100
-          }
-          volume_2 = {
-            id   = "volume-id-2"
-            name = "app_name_instance_name_01_volume2"
-            size = 50
-          }
-        }
-        ```
-
-      home: https://github.com/ewcloud/ewc-tf-module-openstack-compute/tree/1.4.0
+      home: https://github.com/ewcloud/ewc-tf-module-openstack-compute/tree/1.5.0
       sources:
         - https://github.com/ewcloud/ewc-tf-module-openstack-compute.git
       maintainers:
@@ -423,7 +382,7 @@ spec:
         licenseType: "MIT License"
       displayName: OpenStack Compute Instance
       summary: Simplifies the creation of EWC VMs, or state update and teardown of existing ones, via Terraform.
-      license: https://github.com/ewcloud/ewc-tf-module-openstack-compute/blob/1.4.0/LICENSE
+      license: https://github.com/ewcloud/ewc-tf-module-openstack-compute/blob/1.5.0/LICENSE
       published: true
 
     ewc-tf-module-openstack-security-group:


### PR DESCRIPTION
Hey @pacospace,
This PR indexes the new version of the `ewc-tf-module-openstack-compute` Item into the hub catalog. 

The new version includes documentation and sensible defaults for deploying on the new EUMETSAT cloud   (see https://github.com/ewcloud/ewc-tf-module-openstack-compute/pull/3 for details).