### PR TITLE
End-to-end test parallelism

### DIFF
--- a/.github/workflows/test-deployment-ansible-ecmwf.yml
+++ b/.github/workflows/test-deployment-ansible-ecmwf.yml
@@ -57,8 +57,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ vars.APP_CLIENT_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          client-id: ${{ vars.EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_CLIENT_ID }}
+          private-key: ${{ secrets.EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       - name: Orchestrate deployments testing

--- a/.github/workflows/test-deployment-ansible-eumetsat.yml
+++ b/.github/workflows/test-deployment-ansible-eumetsat.yml
@@ -57,8 +57,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ vars.APP_CLIENT_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          client-id: ${{ vars.EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_CLIENT_ID }}
+          private-key: ${{ secrets.EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       - name: Orchestrate deployments testing

--- a/.github/workflows/test-deployment-ansible-via-ewccli-ecmwf.yml
+++ b/.github/workflows/test-deployment-ansible-via-ewccli-ecmwf.yml
@@ -57,8 +57,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ vars.APP_CLIENT_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          client-id: ${{ vars.EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_CLIENT_ID }}
+          private-key: ${{ secrets.EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       - name: Orchestrate deployments testing

--- a/.github/workflows/test-deployment-ansible-via-ewccli-eumetsat.yml
+++ b/.github/workflows/test-deployment-ansible-via-ewccli-eumetsat.yml
@@ -57,8 +57,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ vars.APP_CLIENT_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          client-id: ${{ vars.EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_CLIENT_ID }}
+          private-key: ${{ secrets.EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       - name: Orchestrate deployments testing

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -71,8 +71,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ vars.APP_CLIENT_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          client-id: ${{ vars.EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_CLIENT_ID }}
+          private-key: ${{ secrets.EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       - name: Orchestrate deployments testing
@@ -107,8 +107,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ vars.APP_CLIENT_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          client-id: ${{ vars.EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_CLIENT_ID }}
+          private-key: ${{ secrets.EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       - name: Orchestrate deployments testing
@@ -144,8 +144,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ vars.APP_CLIENT_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          client-id: ${{ vars.EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_CLIENT_ID }}
+          private-key: ${{ secrets.EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       - name: Orchestrate deployments testing
@@ -182,8 +182,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ vars.APP_CLIENT_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          client-id: ${{ vars.EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_CLIENT_ID }}
+          private-key: ${{ secrets.EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       - name: Orchestrate deployments testing

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,8 +8,7 @@ on:
 env:
   POLLING_INTERVAL_SECONDS: 60
   RUN_TIMEOUT_MINUTES: 20 # Max runtime per each downstream workflow run
-  MAX_CONCURRENT_WORKFLOWS: 2
-
+  MAX_CONCURRENT_WORKFLOWS: 1
 jobs:
   lint:
     name: Metadata Linting

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -124,8 +124,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 200
     environment: ECMWF
-    needs: test-deploy-ansible-ecmwf
-    if: ${{ always() }}
+    needs: lint
 
     steps:
       - name: Checkout catalog repository
@@ -162,8 +161,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 300
     environment: EUMETSAT
-    needs: test-deploy-ansible-eumetsat
-    if: ${{ always() }}
+    needs: lint
 
     steps:
       - name: Checkout catalog repository


### PR DESCRIPTION
This PR is a follow up step towards improving the usefulness of catalog-centric test automation. 

With Items that won't be maintained out of the list  (see https://github.com/ewcloud/ewc-community-hub/pull/86 ), we now aim at running all workflow jobs for test deployment in parallel to provide clearer test dependencies, or rather lack thereof. 

The following step is to re-raise all step-level errors up to the orchestration level for getting a sense of status from high level widgets such as the Deployment status on the home page of the repository (right side column, middle of the screen). 


**Whats new**
* All 4 test jobs run in parallel and execute one Item deployment at a time


**Pending Points**

* Upon merging this PR, the `APP_CLIENT_ID` GitHub Action Variable and the `APP_PRIVATE_KEY` GitHub Action Secret both should be deleted (the Org-level `EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_PRIVATE_KEY` and `EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_CLIENT_ID` replaced them).
