### PR TITLE
Bump EWCCLI version to 0.7.0

### DIFF
--- a/items.yaml
+++ b/items.yaml
@@ -1461,13 +1461,13 @@ spec:
 
     ewccli:
       name: "ewccli"
-      version: "0.6.0"
+      version: "0.7.0"
       description: |
         The `ewccli` is the European Weather Cloud (EWC) Command Line Interface (CLI). This tool is developed to support EWC users on the use of the EWC services.
 
         ## Prerequisites
 
-        - You will need a python environment to run the library implementation of this code. Python version **3.11** or higher.
+        - You will need a python environment to run the library implementation of this code. Python version **3.10** or higher.
         - **git** installed on your operating system. (usually is available to most OS nowadays)
 
         ### Openstack inputs
@@ -1623,7 +1623,7 @@ spec:
 
         you can take advantage of the `--path-to-catalog` to point the EWCCLI to the correct source location, and deploy the Item to your target tenant of choice.
 
-      home: https://github.com/ewcloud/ewccli/tree/0.6.0
+      home: https://github.com/ewcloud/ewccli/tree/0.7.0
       sources:
         - https://github.com/ewcloud/ewccli.git
       maintainers:
@@ -1637,7 +1637,7 @@ spec:
         licenseType: "GNU General Public License v3.0"
       displayName: EWC CLI
       summary: European Weather Cloud (EWC) Command Line Interface (CLI) to interact with EWC services.
-      license: https://github.com/ewcloud/ewccli/blob/0.6.0/LICENSE
+      license: https://github.com/ewcloud/ewccli/blob/0.7.0/LICENSE
       published: true
 
     ewc-gh-action-test-deploy-ansible-playbook:


### PR DESCRIPTION
Hey @pacospace,

This one follows from the release of [EWCCLI 0.7.0](https://github.com/ewcloud/ewccli/commit/c4072120a05434d0903cc18e73d1c51cffb47cb8).