### PR TITLE
Short-lived token generation as 1st step on every CI deployment job

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -55,6 +55,14 @@ jobs:
     needs: lint
 
     steps:
+      - name: Generate installation token for EWC Community Hub CI Orchestrator GitHub App
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_CLIENT_ID }}
+          private-key: ${{ secrets.EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Checkout catalog repository
         uses: actions/checkout@v6
 
@@ -65,14 +73,6 @@ jobs:
 
       - name: Install additional dependencies
         run: pip install -r .github/scripts/orchestrator/requirements.txt
-
-      - name: Generate installation token for EWC Community Hub CI Orchestrator GitHub App
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ vars.EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_CLIENT_ID }}
-          private-key: ${{ secrets.EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
 
       - name: Orchestrate deployments testing
         run: python .github/scripts/orchestrator/main.py
@@ -91,6 +91,14 @@ jobs:
     needs: lint
 
     steps:
+      - name: Generate installation token for EWC Community Hub CI Orchestrator GitHub App
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_CLIENT_ID }}
+          private-key: ${{ secrets.EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Checkout catalog repository
         uses: actions/checkout@v6
 
@@ -101,14 +109,6 @@ jobs:
 
       - name: Install additional dependencies
         run: pip install -r .github/scripts/orchestrator/requirements.txt
-
-      - name: Generate installation token for EWC Community Hub CI Orchestrator GitHub App
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ vars.EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_CLIENT_ID }}
-          private-key: ${{ secrets.EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
 
       - name: Orchestrate deployments testing
         run: python .github/scripts/orchestrator/main.py
@@ -127,6 +127,14 @@ jobs:
     needs: lint
 
     steps:
+      - name: Generate installation token for EWC Community Hub CI Orchestrator GitHub App
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_CLIENT_ID }}
+          private-key: ${{ secrets.EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Checkout catalog repository
         uses: actions/checkout@v6
 
@@ -137,14 +145,6 @@ jobs:
 
       - name: Install additional dependencies
         run: pip install -r .github/scripts/orchestrator/requirements.txt
-
-      - name: Generate installation token for EWC Community Hub CI Orchestrator GitHub App
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ vars.EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_CLIENT_ID }}
-          private-key: ${{ secrets.EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
 
       - name: Orchestrate deployments testing
         run: python .github/scripts/orchestrator/main.py
@@ -164,6 +164,14 @@ jobs:
     needs: lint
 
     steps:
+      - name: Generate installation token for EWC Community Hub CI Orchestrator GitHub App
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_CLIENT_ID }}
+          private-key: ${{ secrets.EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Checkout catalog repository
         uses: actions/checkout@v6
 
@@ -174,14 +182,6 @@ jobs:
 
       - name: Install additional dependencies
         run: pip install -r .github/scripts/orchestrator/requirements.txt
-
-      - name: Generate installation token for EWC Community Hub CI Orchestrator GitHub App
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ vars.EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_CLIENT_ID }}
-          private-key: ${{ secrets.EWC_COMMUNITY_HUB_CI_ORCHESTRATOR_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
 
       - name: Orchestrate deployments testing
         run: python .github/scripts/orchestrator/main.py


### PR DESCRIPTION
This PR fixes a CI auth issue introduced on #93.

**Technical Note**
When running GitHub Actions with short-lived access tokens belonging to a [GitHub App](https://github.com/organizations/ewcloud/settings/apps/ewc-community-hub-ci-orchestrator), the first step on each workflow job must be the token generation.